### PR TITLE
Generate alias for CxlRejResponseTo(434) value

### DIFF
--- a/philadelphia-fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42Enumerations.java
+++ b/philadelphia-fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42Enumerations.java
@@ -1504,8 +1504,9 @@ public class FIX42Enumerations {
      */
     public static class CxlRejResponseToValues {
 
-        public static final char OrderCancelRequest = '1';
-        public static final char OrderCancel        = '2';
+        public static final char OrderCancelRequest        = '1';
+        public static final char OrderCancel               = '2';
+        public static final char OrderCancelReplaceRequest = '2';
 
         private CxlRejResponseToValues() {
         }

--- a/philadelphia-fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43Enumerations.java
+++ b/philadelphia-fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43Enumerations.java
@@ -1761,8 +1761,9 @@ public class FIX43Enumerations {
      */
     public static class CxlRejResponseToValues {
 
-        public static final char OrderCancel        = '2';
-        public static final char OrderCancelRequest = '1';
+        public static final char OrderCancel               = '2';
+        public static final char OrderCancelReplaceRequest = '2';
+        public static final char OrderCancelRequest        = '1';
 
         private CxlRejResponseToValues() {
         }

--- a/philadelphia-fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44Enumerations.java
+++ b/philadelphia-fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44Enumerations.java
@@ -1768,8 +1768,9 @@ public class FIX44Enumerations {
      */
     public static class CxlRejResponseToValues {
 
-        public static final char OrderCancelRequest = '1';
-        public static final char OrderCancel        = '2';
+        public static final char OrderCancelRequest        = '1';
+        public static final char OrderCancel               = '2';
+        public static final char OrderCancelReplaceRequest = '2';
 
         private CxlRejResponseToValues() {
         }

--- a/philadelphia-fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50Enumerations.java
+++ b/philadelphia-fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50Enumerations.java
@@ -1988,8 +1988,9 @@ public class FIX50Enumerations {
      */
     public static class CxlRejResponseToValues {
 
-        public static final char OrderCancelRequest = '1';
-        public static final char OrderCancel        = '2';
+        public static final char OrderCancelRequest        = '1';
+        public static final char OrderCancel               = '2';
+        public static final char OrderCancelReplaceRequest = '2';
 
         private CxlRejResponseToValues() {
         }

--- a/philadelphia-fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1Enumerations.java
+++ b/philadelphia-fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1Enumerations.java
@@ -2089,8 +2089,9 @@ public class FIX50SP1Enumerations {
      */
     public static class CxlRejResponseToValues {
 
-        public static final char OrderCancelRequest = '1';
-        public static final char OrderCancel        = '2';
+        public static final char OrderCancelRequest        = '1';
+        public static final char OrderCancel               = '2';
+        public static final char OrderCancelReplaceRequest = '2';
 
         private CxlRejResponseToValues() {
         }

--- a/philadelphia-fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2Enumerations.java
+++ b/philadelphia-fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2Enumerations.java
@@ -2107,8 +2107,9 @@ public class FIX50SP2Enumerations {
      */
     public static class CxlRejResponseToValues {
 
-        public static final char OrderCancelRequest = '1';
-        public static final char OrderCancel        = '2';
+        public static final char OrderCancelRequest        = '1';
+        public static final char OrderCancel               = '2';
+        public static final char OrderCancelReplaceRequest = '2';
 
         private CxlRejResponseToValues() {
         }

--- a/scripts/generate
+++ b/scripts/generate
@@ -10,17 +10,26 @@ import xml.etree.ElementTree
 
 INDENT = '    '
 
+SYMBOLIC_NAME_ALIASES = {
+    ('434', '2'): [
+        'OrderCancelReplaceRequest',
+    ],
+}
+
 Enum = collections.namedtuple('Enum', ['tag', 'value', 'symbolic_name', 'sort'])
 
 def read_enums(infile):
-    def enum(elem):
+    def enum_with_aliases(elem):
         tag = elem.find('Tag').text
         value = elem.find('Value').text
         symbolic_name = elem.find('SymbolicName').text
         sort = int(elem.find('Sort').text) if elem.find('Sort') is not None else None
-        return Enum(tag, value, symbolic_name, sort)
+        enum = Enum(tag, value, symbolic_name, sort)
+        return [enum] + [enum._replace(symbolic_name=symbolic_name_alias)
+                for symbolic_name_alias in SYMBOLIC_NAME_ALIASES.get((tag, value), [])]
     tree = xml.etree.ElementTree.parse(infile)
-    return [enum(elem) for elem in tree.findall('Enum')]
+    enums = [enum_with_aliases(elem) for elem in tree.findall('Enum')]
+    return [enum for aliases in enums for enum in aliases]
 
 Field = collections.namedtuple('Field', ['tag', 'name', 'type'])
 


### PR DESCRIPTION
The symbolic names generated for enumerations are based on the symbolic names contained in the FIX Repository. The CxlRejResponseTo(434) values look as follows:

Value | Symbolic Name | Description
-|-|-
1 | `OrderCancelRequest` | Order Cancel Request
2 | `OrderCancel` | Order Cancel/Replace Request

The symbolic name `OrderCancel` for the value that indicates an Order Cancel/Replace Request message is confusing. Fix this by generating an alias with the symbolic name `OrderCancelReplaceRequest`.

Fixes #32.