### PR TITLE
Reduce size of FIXSession.MessageHandler method

### DIFF
--- a/philadelphia/src/main/java/com/paritytrading/philadelphia/FIXSession.java
+++ b/philadelphia/src/main/java/com/paritytrading/philadelphia/FIXSession.java
@@ -524,7 +524,7 @@ public class FIXSession implements Closeable {
             }
 
             if (msgType.length() == 1 && msgType.asChar() == SequenceReset) {
-                if(handleSequenceReset(message))
+                if (handleSequenceReset(message))
                     return;
             }
 
@@ -534,7 +534,7 @@ public class FIXSession implements Closeable {
             }
 
             if (msgSeqNum < rxMsgSeqNum) {
-                handleTooLowMsgSeqNum(message, msgSeqNum, msgType);
+                handleTooLowMsgSeqNum(message, msgType, msgSeqNum);
                 return;
             }
 
@@ -573,7 +573,7 @@ public class FIXSession implements Closeable {
             }
         }
 
-        private void handleTooLowMsgSeqNum(FIXMessage message, long msgSeqNum, FIXValue msgType) throws IOException {
+        private void handleTooLowMsgSeqNum(FIXMessage message, FIXValue msgType, long msgSeqNum) throws IOException {
             if (msgType.length() != 1 || msgType.asChar() != SequenceReset) {
                 FIXValue possDupFlag = message.findField(PossDupFlag);
 

--- a/philadelphia/src/main/java/com/paritytrading/philadelphia/FIXSession.java
+++ b/philadelphia/src/main/java/com/paritytrading/philadelphia/FIXSession.java
@@ -572,7 +572,7 @@ public class FIXSession implements Closeable {
             }
         }
 
-        private void handleTooLowMsgSeqNum(final FIXMessage message, final long msgSeqNum, final FIXValue msgType) throws IOException {
+        private void handleTooLowMsgSeqNum(FIXMessage message, long msgSeqNum, FIXValue msgType) throws IOException {
             if (msgType.length() != 1 || msgType.asChar() != SequenceReset) {
                 FIXValue possDupFlag = message.findField(PossDupFlag);
 


### PR DESCRIPTION
This is an issue / PR, the commits just make it clearer.

Every FIX message passes through the `FIXSession.MessageHandler.message` method, so it's on the critical path of most FIX applications. Unfortunately with 391 bytes in size it's the only method in Philadelphia larger than the 325 bytes default jvm hot method inline size.

The commit below reduces the size of the method to 315 bytes which allows inlining. Running the Philadelphia ping pong test before:
```
@ 275   com.paritytrading.philadelphia.FIXSession$MessageHandler::message (391 bytes)   hot method too big
```
after:
```
@ 275   com.paritytrading.philadelphia.FIXSession$MessageHandler::message (315 bytes)   inline (hot)
```

The removal of the check at line 553 should be fine as any message with 2 bytes message type is not the most common message type and caught by the default-case in the switch statement (assuming no such message type would match 0-A in the first byte which would be retarded). As we are not doing the length check anymore we directly access the char at offset 0, and if there's no match it passes it downstream.