### PR TITLE
philadelphia-client: General improvements

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
@@ -65,6 +65,9 @@ public class TerminalClient implements Closeable {
             if (line == null)
                 break;
 
+            if (line.trim().startsWith("#"))
+                continue;
+
             Scanner scanner = scan(line);
 
             if (!scanner.hasNext())

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/Commands.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/Commands.java
@@ -9,7 +9,8 @@ public class Commands {
             new SendCommand(),
             new MessagesCommand(),
             new HelpCommand(),
-            new ExitCommand()
+            new ExitCommand(),
+            new SleepCommand()
         );
 
     private Commands() {

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/MessagesCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/MessagesCommand.java
@@ -4,16 +4,30 @@ import com.paritytrading.philadelphia.client.TerminalClient;
 import com.paritytrading.philadelphia.client.message.Message;
 import com.paritytrading.philadelphia.client.message.Messages;
 import java.util.Scanner;
+import org.eclipse.collections.api.list.ImmutableList;
 
 class MessagesCommand implements Command {
 
     @Override
     public void execute(TerminalClient client, Scanner arguments) throws CommandException {
-        if (arguments.hasNext())
-            throw new CommandException();
+        if (arguments.hasNext()) {
+            int index = arguments.nextInt();
 
-        for (Message message : client.getMessages().collect())
-            client.printf("%s\n", message);
+            ImmutableList<Message> messages = client.getMessages().collect();
+
+            if (index >= 0 && index < +messages.size())
+                client.printf("%s\n", messages.get(index));
+
+            if (index >= -messages.size() && index < 0)
+                client.printf("%s\n", messages.get(index + messages.size()));
+
+            if (arguments.hasNext())
+                throw new CommandException();
+        }
+        else {
+            for (Message message : client.getMessages().collect())
+                client.printf("%s\n", message);
+        }
     }
 
     @Override
@@ -28,7 +42,7 @@ class MessagesCommand implements Command {
 
     @Override
     public String getUsage() {
-        return "messages";
+        return "messages [<index>]";
     }
 
 }

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/SleepCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/SleepCommand.java
@@ -1,0 +1,39 @@
+package com.paritytrading.philadelphia.client.command;
+
+import com.paritytrading.philadelphia.client.TerminalClient;
+import java.util.Scanner;
+
+class SleepCommand implements Command {
+
+    @Override
+    public void execute(TerminalClient client, Scanner arguments) throws CommandException {
+        if (!arguments.hasNext())
+            throw new CommandException();
+
+        long millis = arguments.nextLong();
+
+        if (arguments.hasNext())
+            throw new CommandException();
+
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "sleep";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Sleep for a number of milliseconds";
+    }
+
+    @Override
+    public String getUsage() {
+        return "sleep <milliseconds>";
+    }
+
+}


### PR DESCRIPTION
- Add comment support: treat lines starting with `#` as comments.
- Add input file support: make it possible to run Philadelphia Terminal Client scripts.
- Improve `messages` command: add support for optional `index` parameter.
- Add `sleep` command: make the interpreter sleep for a number of milliseconds.