### PR TITLE
philadelphia-core: Make it possible to set number of fields

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
@@ -88,6 +88,15 @@ public class FIXMessage {
     }
 
     /**
+     * Set the number of fields.
+     *
+     * @param count the number of fields
+     */
+    public void setFieldCount(int count) {
+        this.count = count;
+    }
+
+    /**
      * Get the value container of the first instance of a field with the
      * specified tag.
      *


### PR DESCRIPTION
This is useful when working with message templates for messages with variable number of fields (e.g. due to repeating groups): the initial fixed-length portion will constitute the message template while the
subsequent variable-length portion will be built from scratch every time.