### PR TITLE
philadelphia-core: Avoid unnecessary method call on socket write

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXSession.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXSession.java
@@ -436,7 +436,7 @@ public class FIXSession implements Closeable {
         int remaining = txHeaderBuffer.remaining() + txBodyBuffer.remaining();
 
         do {
-            remaining -= channel.write(txBuffers);
+            remaining -= channel.write(txBuffers, 0, txBuffers.length);
         } while (remaining > 0);
 
         txMsgSeqNum++;


### PR DESCRIPTION
Save one level of inline depth on send path as `channel.write(txBuffers)` effectively calls `channel.write(txBuffers, 0, txBuffers.length)`.

Tested running acceptor/initiator.