### PR TITLE
philadelphia-core: Simplify message header and trailer handling

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIX.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIX.java
@@ -6,6 +6,12 @@ class FIX {
 
     static final byte SOH = 1;
 
+    static final byte[] BEGIN_STRING = new byte[] { '8', '=' };
+
+    static final byte[] BODY_LENGTH = new byte[] { '9', '=' };
+
+    static final byte[] CHECK_SUM = new byte[] { '1', '0', '=' };
+
     static final int BEGIN_STRING_FIELD_CAPACITY = 16;
 
     static final int BODY_LENGTH_FIELD_CAPACITY = 16;

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -419,15 +419,15 @@ public class FIXConnection implements Closeable {
         bodyLength.setInt(txBodyBuffer.position());
 
         txHeaderBuffer.clear();
-        FIXTags.put(txHeaderBuffer, BeginString);
+        txHeaderBuffer.put(BEGIN_STRING);
         beginString.put(txHeaderBuffer);
-        FIXTags.put(txHeaderBuffer, BodyLength);
+        txHeaderBuffer.put(BODY_LENGTH);
         bodyLength.put(txHeaderBuffer);
 
         checkSum.setCheckSum(FIXCheckSums.sum(txHeaderBuffer, 0, txHeaderBuffer.position()) +
                 FIXCheckSums.sum(txBodyBuffer, 0, txBodyBuffer.position()));
 
-        FIXTags.put(txBodyBuffer, CheckSum);
+        txBodyBuffer.put(CHECK_SUM);
         checkSum.put(txBodyBuffer);
 
         txHeaderBuffer.flip();


### PR DESCRIPTION
- Use preformatted byte arrays for the BeginString(8), BodyLength(9), and CheckSum(10) tags
- When sending a message, instead of formatting the entire message header, only format the BodyLength(9) value