### PR TITLE
philadelphia-core: Optimize 'FIXConnection#update' and 'FIXConnection#updateCompID'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -275,21 +275,12 @@ public class FIXConnection implements Closeable {
      * </ul>
      *
      * @param message a message
-     * @throws IllegalStateException if MsgSeqNum(34) or SendingTime(52) is
+     * @throws NullPointerException if MsgSeqNum(34) or SendingTime(52) is
      *   not found
      */
     public void update(FIXMessage message) {
-        FIXValue msgSeqNum = message.valueOf(MsgSeqNum);
-        if (msgSeqNum == null)
-            msgSeqNumNotFound();
-
-        msgSeqNum.setInt(txMsgSeqNum);
-
-        FIXValue sendingTime = message.valueOf(SendingTime);
-        if (sendingTime == null)
-            sendingTimeNotFound();
-
-        sendingTime.setString(currentTimestamp);
+        message.valueOf(MsgSeqNum).setInt(txMsgSeqNum);
+        message.valueOf(SendingTime).setString(currentTimestamp);
     }
 
     /**
@@ -731,14 +722,6 @@ public class FIXConnection implements Closeable {
         txMessage.addField(NewSeqNo).setInt(newSeqNo);
 
         send(txMessage);
-    }
-
-    private static void msgSeqNumNotFound() {
-        throw new IllegalStateException("MsgSeqNum(34) not found");
-    }
-
-    private static void sendingTimeNotFound() {
-        throw new IllegalStateException("SendingTime(52) not found");
     }
 
     private static void senderCompIDNotFound() {

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -287,23 +287,12 @@ public class FIXConnection implements Closeable {
      * Update SenderCompID(49) and TargetCompID(56).
      *
      * @param message a message
-     * @throws IllegalStateException if SenderCompID(49) or TargetCompID(56)
+     * @throws NullPointerException if SenderCompID(49) or TargetCompID(56)
      *   is not found
      */
     public void updateCompID(FIXMessage message) {
-        FIXValue value;
-
-        value = message.valueOf(SenderCompID);
-        if (value == null)
-            senderCompIDNotFound();
-
-        value.setString(senderCompId);
-
-        value = message.valueOf(TargetCompID);
-        if (value == null)
-            targetCompIDNotFound();
-
-        value.setString(targetCompId);
+        message.valueOf(SenderCompID).setString(senderCompId);
+        message.valueOf(TargetCompID).setString(targetCompId);
     }
 
     /**
@@ -722,14 +711,6 @@ public class FIXConnection implements Closeable {
         txMessage.addField(NewSeqNo).setInt(newSeqNo);
 
         send(txMessage);
-    }
-
-    private static void senderCompIDNotFound() {
-        throw new IllegalStateException("SenderCompID(49) not found");
-    }
-
-    private static void targetCompIDNotFound() {
-        throw new IllegalStateException("TargetCompID(56) not found");
     }
 
     private static void tooLongMessage() throws FIXMessageOverflowException {


### PR DESCRIPTION
Remove explicit `null` checks. This reduces the bytecode sizes from 45 bytes to 27 bytes, which is under HotSpot's default maximum inline size of 35 bytes.

**Note.** This is an API change as these methods will no longer throw an `InvalidStateException` but might throw a `NullPointerException` instead. Both being unchecked exceptions, I would argue that this is a backwards compatible API change. Thoughts?