### PR TITLE
philadelphia-generate: Improve enumeration handling

### DIFF
--- a/applications/generate/philadelphia/repository.py
+++ b/applications/generate/philadelphia/repository.py
@@ -82,6 +82,8 @@ def _type(field_type, values):
     type_ = _TYPES.get(field_type)
     if type_ == 'char' and values and max(len(value.value) for value in values) > 1:
         return 'String'
+    elif type_ == 'String' and all(len(value.value) == 1 for value in values):
+        return 'char'
     else:
         return type_
 

--- a/libraries/fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42Enumerations.java
+++ b/libraries/fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42Enumerations.java
@@ -25,9 +25,9 @@ public class FIX42Enumerations {
      */
     public static class AdvTransTypeValues {
 
-        public static final String Cancel  = "C";
-        public static final String New     = "N";
-        public static final String Replace = "R";
+        public static final char Cancel  = 'C';
+        public static final char New     = 'N';
+        public static final char Replace = 'R';
 
         private AdvTransTypeValues() {
         }
@@ -53,35 +53,35 @@ public class FIX42Enumerations {
      */
     public static class ExecInstValues {
 
-        public static final String StayOnOfferSide                            = "0";
-        public static final String NotHeld                                    = "1";
-        public static final String Work                                       = "2";
-        public static final String GoAlong                                    = "3";
-        public static final String OverTheDay                                 = "4";
-        public static final String Held                                       = "5";
-        public static final String ParticipateDoNotInitiate                   = "6";
-        public static final String StrictScale                                = "7";
-        public static final String TryToScale                                 = "8";
-        public static final String StayOnBidSide                              = "9";
-        public static final String NoCross                                    = "A";
-        public static final String OKToCross                                  = "B";
-        public static final String CallFirst                                  = "C";
-        public static final String PercentOfVolume                            = "D";
-        public static final String DoNotIncrease                              = "E";
-        public static final String DoNotReduce                                = "F";
-        public static final String AllOrNone                                  = "G";
-        public static final String InstitutionsOnly                           = "I";
-        public static final String LastPeg                                    = "L";
-        public static final String MidPricePeg                                = "M";
-        public static final String NonNegotiable                              = "N";
-        public static final String OpeningPeg                                 = "O";
-        public static final String MarketPeg                                  = "P";
-        public static final String PrimaryPeg                                 = "R";
-        public static final String Suspend                                    = "S";
-        public static final String FixedPegToLocalBestBidOrOfferAtTimeOfOrder = "T";
-        public static final String CustomerDisplayInstruction                 = "U";
-        public static final String Netting                                    = "V";
-        public static final String PegToVWAP                                  = "W";
+        public static final char StayOnOfferSide                            = '0';
+        public static final char NotHeld                                    = '1';
+        public static final char Work                                       = '2';
+        public static final char GoAlong                                    = '3';
+        public static final char OverTheDay                                 = '4';
+        public static final char Held                                       = '5';
+        public static final char ParticipateDoNotInitiate                   = '6';
+        public static final char StrictScale                                = '7';
+        public static final char TryToScale                                 = '8';
+        public static final char StayOnBidSide                              = '9';
+        public static final char NoCross                                    = 'A';
+        public static final char OKToCross                                  = 'B';
+        public static final char CallFirst                                  = 'C';
+        public static final char PercentOfVolume                            = 'D';
+        public static final char DoNotIncrease                              = 'E';
+        public static final char DoNotReduce                                = 'F';
+        public static final char AllOrNone                                  = 'G';
+        public static final char InstitutionsOnly                           = 'I';
+        public static final char LastPeg                                    = 'L';
+        public static final char MidPricePeg                                = 'M';
+        public static final char NonNegotiable                              = 'N';
+        public static final char OpeningPeg                                 = 'O';
+        public static final char MarketPeg                                  = 'P';
+        public static final char PrimaryPeg                                 = 'R';
+        public static final char Suspend                                    = 'S';
+        public static final char FixedPegToLocalBestBidOrOfferAtTimeOfOrder = 'T';
+        public static final char CustomerDisplayInstruction                 = 'U';
+        public static final char Netting                                    = 'V';
+        public static final char PegToVWAP                                  = 'W';
 
         private ExecInstValues() {
         }
@@ -122,15 +122,15 @@ public class FIX42Enumerations {
      */
     public static class IDSourceValues {
 
-        public static final String CUSIP                       = "1";
-        public static final String SEDOL                       = "2";
-        public static final String QUIK                        = "3";
-        public static final String ISINNumber                  = "4";
-        public static final String RICCode                     = "5";
-        public static final String ISOCurrencyCode             = "6";
-        public static final String ISOCountryCode              = "7";
-        public static final String ExchangeSymbol              = "8";
-        public static final String ConsolidatedTapeAssociation = "9";
+        public static final char CUSIP                       = '1';
+        public static final char SEDOL                       = '2';
+        public static final char QUIK                        = '3';
+        public static final char ISINNumber                  = '4';
+        public static final char RICCode                     = '5';
+        public static final char ISOCurrencyCode             = '6';
+        public static final char ISOCountryCode              = '7';
+        public static final char ExchangeSymbol              = '8';
+        public static final char ConsolidatedTapeAssociation = '9';
 
         private IDSourceValues() {
         }
@@ -156,9 +156,9 @@ public class FIX42Enumerations {
      */
     public static class IOISharesValues {
 
-        public static final String Large  = "L";
-        public static final String Medium = "M";
-        public static final String Small  = "S";
+        public static final char Large  = 'L';
+        public static final char Medium = 'M';
+        public static final char Small  = 'S';
 
         private IOISharesValues() {
         }
@@ -884,15 +884,15 @@ public class FIX42Enumerations {
      */
     public static class QuoteConditionValues {
 
-        public static final String Open             = "A";
-        public static final String Closed           = "B";
-        public static final String ExchangeBest     = "C";
-        public static final String ConsolidatedBest = "D";
-        public static final String Locked           = "E";
-        public static final String Crossed          = "F";
-        public static final String Depth            = "G";
-        public static final String FastTrading      = "H";
-        public static final String NonFirm          = "I";
+        public static final char Open             = 'A';
+        public static final char Closed           = 'B';
+        public static final char ExchangeBest     = 'C';
+        public static final char ConsolidatedBest = 'D';
+        public static final char Locked           = 'E';
+        public static final char Crossed          = 'F';
+        public static final char Depth            = 'G';
+        public static final char FastTrading      = 'H';
+        public static final char NonFirm          = 'I';
 
         private QuoteConditionValues() {
         }
@@ -904,20 +904,20 @@ public class FIX42Enumerations {
      */
     public static class TradeConditionValues {
 
-        public static final String Cash                = "A";
-        public static final String AveragePriceTrade   = "B";
-        public static final String CashTrade           = "C";
-        public static final String NextDay             = "D";
-        public static final String Opening             = "E";
-        public static final String IntradayTradeDetail = "F";
-        public static final String Rule127Trade        = "G";
-        public static final String Rule155Trade        = "H";
-        public static final String SoldLast            = "I";
-        public static final String NextDayTrade        = "J";
-        public static final String Opened              = "K";
-        public static final String Seller              = "L";
-        public static final String Sold                = "M";
-        public static final String StoppedStock        = "N";
+        public static final char Cash                = 'A';
+        public static final char AveragePriceTrade   = 'B';
+        public static final char CashTrade           = 'C';
+        public static final char NextDay             = 'D';
+        public static final char Opening             = 'E';
+        public static final char IntradayTradeDetail = 'F';
+        public static final char Rule127Trade        = 'G';
+        public static final char Rule155Trade        = 'H';
+        public static final char SoldLast            = 'I';
+        public static final char NextDayTrade        = 'J';
+        public static final char Opened              = 'K';
+        public static final char Seller              = 'L';
+        public static final char Sold                = 'M';
+        public static final char StoppedStock        = 'N';
 
         private TradeConditionValues() {
         }

--- a/libraries/fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43Enumerations.java
+++ b/libraries/fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43Enumerations.java
@@ -25,9 +25,9 @@ public class FIX43Enumerations {
      */
     public static class AdvTransTypeValues {
 
-        public static final String New     = "N";
-        public static final String Cancel  = "C";
-        public static final String Replace = "R";
+        public static final char New     = 'N';
+        public static final char Cancel  = 'C';
+        public static final char Replace = 'R';
 
         private AdvTransTypeValues() {
         }
@@ -56,40 +56,40 @@ public class FIX43Enumerations {
      */
     public static class ExecInstValues {
 
-        public static final String TryToStop                  = "Y";
-        public static final String MidPricePeg                = "M";
-        public static final String MarketPeg                  = "P";
-        public static final String CancelOnSystemFailure      = "Q";
-        public static final String PrimaryPeg                 = "R";
-        public static final String Suspend                    = "S";
-        public static final String CustomerDisplayInstruction = "U";
-        public static final String Netting                    = "V";
-        public static final String PegToVWAP                  = "W";
-        public static final String TradeAlong                 = "X";
-        public static final String PercentOfVolume            = "D";
-        public static final String StayOnOfferSide            = "0";
-        public static final String Work                       = "2";
-        public static final String OverTheDay                 = "4";
-        public static final String Held                       = "5";
-        public static final String ParticipateDoNotInitiate   = "6";
-        public static final String StrictScale                = "7";
-        public static final String TryToScale                 = "8";
-        public static final String StayOnBidSide              = "9";
-        public static final String NoCross                    = "A";
-        public static final String OpeningPeg                 = "O";
-        public static final String CallFirst                  = "C";
-        public static final String NonNegotiable              = "N";
-        public static final String DoNotIncrease              = "E";
-        public static final String DoNotReduce                = "F";
-        public static final String AllOrNone                  = "G";
-        public static final String ReinstateOnSystemFailure   = "H";
-        public static final String InstitutionsOnly           = "I";
-        public static final String ReinstateOnTradingHalt     = "J";
-        public static final String CancelOnTradingHalt        = "K";
-        public static final String LastPeg                    = "L";
-        public static final String GoAlong                    = "3";
-        public static final String OKToCross                  = "B";
-        public static final String NotHeld                    = "1";
+        public static final char TryToStop                  = 'Y';
+        public static final char MidPricePeg                = 'M';
+        public static final char MarketPeg                  = 'P';
+        public static final char CancelOnSystemFailure      = 'Q';
+        public static final char PrimaryPeg                 = 'R';
+        public static final char Suspend                    = 'S';
+        public static final char CustomerDisplayInstruction = 'U';
+        public static final char Netting                    = 'V';
+        public static final char PegToVWAP                  = 'W';
+        public static final char TradeAlong                 = 'X';
+        public static final char PercentOfVolume            = 'D';
+        public static final char StayOnOfferSide            = '0';
+        public static final char Work                       = '2';
+        public static final char OverTheDay                 = '4';
+        public static final char Held                       = '5';
+        public static final char ParticipateDoNotInitiate   = '6';
+        public static final char StrictScale                = '7';
+        public static final char TryToScale                 = '8';
+        public static final char StayOnBidSide              = '9';
+        public static final char NoCross                    = 'A';
+        public static final char OpeningPeg                 = 'O';
+        public static final char CallFirst                  = 'C';
+        public static final char NonNegotiable              = 'N';
+        public static final char DoNotIncrease              = 'E';
+        public static final char DoNotReduce                = 'F';
+        public static final char AllOrNone                  = 'G';
+        public static final char ReinstateOnSystemFailure   = 'H';
+        public static final char InstitutionsOnly           = 'I';
+        public static final char ReinstateOnTradingHalt     = 'J';
+        public static final char CancelOnTradingHalt        = 'K';
+        public static final char LastPeg                    = 'L';
+        public static final char GoAlong                    = '3';
+        public static final char OKToCross                  = 'B';
+        public static final char NotHeld                    = '1';
 
         private ExecInstValues() {
         }
@@ -115,22 +115,22 @@ public class FIX43Enumerations {
      */
     public static class SecurityIDSourceValues {
 
-        public static final String Sicovam                     = "E";
-        public static final String SEDOL                       = "2";
-        public static final String CUSIP                       = "1";
-        public static final String QUIK                        = "3";
-        public static final String Belgian                     = "F";
-        public static final String Valoren                     = "D";
-        public static final String Dutch                       = "C";
-        public static final String Wertpapier                  = "B";
-        public static final String BloombergSymbol             = "A";
-        public static final String ConsolidatedTapeAssociation = "9";
-        public static final String ExchangeSymbol              = "8";
-        public static final String ISOCountryCode              = "7";
-        public static final String ISOCurrencyCode             = "6";
-        public static final String RICCode                     = "5";
-        public static final String ISINNumber                  = "4";
-        public static final String Common                      = "G";
+        public static final char Sicovam                     = 'E';
+        public static final char SEDOL                       = '2';
+        public static final char CUSIP                       = '1';
+        public static final char QUIK                        = '3';
+        public static final char Belgian                     = 'F';
+        public static final char Valoren                     = 'D';
+        public static final char Dutch                       = 'C';
+        public static final char Wertpapier                  = 'B';
+        public static final char BloombergSymbol             = 'A';
+        public static final char ConsolidatedTapeAssociation = '9';
+        public static final char ExchangeSymbol              = '8';
+        public static final char ISOCountryCode              = '7';
+        public static final char ISOCurrencyCode             = '6';
+        public static final char RICCode                     = '5';
+        public static final char ISINNumber                  = '4';
+        public static final char Common                      = 'G';
 
         private SecurityIDSourceValues() {
         }
@@ -156,9 +156,9 @@ public class FIX43Enumerations {
      */
     public static class IOIQtyValues {
 
-        public static final String Large  = "L";
-        public static final String Medium = "M";
-        public static final String Small  = "S";
+        public static final char Large  = 'L';
+        public static final char Medium = 'M';
+        public static final char Small  = 'S';
 
         private IOIQtyValues() {
         }
@@ -1046,15 +1046,15 @@ public class FIX43Enumerations {
      */
     public static class QuoteConditionValues {
 
-        public static final String Locked           = "E";
-        public static final String NonFirm          = "I";
-        public static final String FastTrading      = "H";
-        public static final String Crossed          = "F";
-        public static final String ConsolidatedBest = "D";
-        public static final String ExchangeBest     = "C";
-        public static final String Closed           = "B";
-        public static final String Open             = "A";
-        public static final String Depth            = "G";
+        public static final char Locked           = 'E';
+        public static final char NonFirm          = 'I';
+        public static final char FastTrading      = 'H';
+        public static final char Crossed          = 'F';
+        public static final char ConsolidatedBest = 'D';
+        public static final char ExchangeBest     = 'C';
+        public static final char Closed           = 'B';
+        public static final char Open             = 'A';
+        public static final char Depth            = 'G';
 
         private QuoteConditionValues() {
         }
@@ -1066,23 +1066,23 @@ public class FIX43Enumerations {
      */
     public static class TradeConditionValues {
 
-        public static final String NextDayTrade         = "J";
-        public static final String Opened               = "K";
-        public static final String Seller               = "L";
-        public static final String AveragePriceTrade    = "B";
-        public static final String Sold                 = "M";
-        public static final String Rule155Trade         = "H";
-        public static final String StoppedStock         = "N";
-        public static final String ImbalanceMoreBuyers  = "P";
-        public static final String ImbalanceMoreSellers = "Q";
-        public static final String OpeningPrice         = "R";
-        public static final String SoldLast             = "I";
-        public static final String Cash                 = "A";
-        public static final String CashTrade            = "C";
-        public static final String Opening              = "E";
-        public static final String IntradayTradeDetail  = "F";
-        public static final String Rule127Trade         = "G";
-        public static final String NextDay              = "D";
+        public static final char NextDayTrade         = 'J';
+        public static final char Opened               = 'K';
+        public static final char Seller               = 'L';
+        public static final char AveragePriceTrade    = 'B';
+        public static final char Sold                 = 'M';
+        public static final char Rule155Trade         = 'H';
+        public static final char StoppedStock         = 'N';
+        public static final char ImbalanceMoreBuyers  = 'P';
+        public static final char ImbalanceMoreSellers = 'Q';
+        public static final char OpeningPrice         = 'R';
+        public static final char SoldLast             = 'I';
+        public static final char Cash                 = 'A';
+        public static final char CashTrade            = 'C';
+        public static final char Opening              = 'E';
+        public static final char IntradayTradeDetail  = 'F';
+        public static final char Rule127Trade         = 'G';
+        public static final char NextDay              = 'D';
 
         private TradeConditionValues() {
         }
@@ -1145,11 +1145,11 @@ public class FIX43Enumerations {
      */
     public static class OpenCloseSettleFlagValues {
 
-        public static final String SessionOpen                  = "1";
-        public static final String DeliverySettlementEntry      = "2";
-        public static final String ExpectedEntry                = "3";
-        public static final String EntryFromPreviousBusinessDay = "4";
-        public static final String DailyOpen                    = "0";
+        public static final char SessionOpen                  = '1';
+        public static final char DeliverySettlementEntry      = '2';
+        public static final char ExpectedEntry                = '3';
+        public static final char EntryFromPreviousBusinessDay = '4';
+        public static final char DailyOpen                    = '0';
 
         private OpenCloseSettleFlagValues() {
         }
@@ -1161,8 +1161,8 @@ public class FIX43Enumerations {
      */
     public static class FinancialStatusValues {
 
-        public static final String Bankrupt         = "1";
-        public static final String PendingDelisting = "2";
+        public static final char Bankrupt         = '1';
+        public static final char PendingDelisting = '2';
 
         private FinancialStatusValues() {
         }
@@ -1174,11 +1174,11 @@ public class FIX43Enumerations {
      */
     public static class CorporateActionValues {
 
-        public static final String ExDistribution = "B";
-        public static final String ExInterest     = "E";
-        public static final String ExRights       = "C";
-        public static final String ExDividend     = "A";
-        public static final String New            = "D";
+        public static final char ExDistribution = 'B';
+        public static final char ExInterest     = 'E';
+        public static final char ExRights       = 'C';
+        public static final char ExDividend     = 'A';
+        public static final char New            = 'D';
 
         private CorporateActionValues() {
         }
@@ -2171,16 +2171,16 @@ public class FIX43Enumerations {
      */
     public static class OrderRestrictionsValues {
 
-        public static final String ForeignEntity                               = "7";
-        public static final String RisklessArbitrage                           = "A";
-        public static final String ProgramTrade                                = "1";
-        public static final String ExternalMarketParticipant                   = "8";
-        public static final String ActingAsMarketMakerOrSpecialistInUnderlying = "6";
-        public static final String ActingAsMarketMakerOrSpecialistInSecurity   = "5";
-        public static final String NonIndexArbitrage                           = "3";
-        public static final String IndexArbitrage                              = "2";
-        public static final String CompetingMarketMaker                        = "4";
-        public static final String ExternalInterConnectedMarketLinkage         = "9";
+        public static final char ForeignEntity                               = '7';
+        public static final char RisklessArbitrage                           = 'A';
+        public static final char ProgramTrade                                = '1';
+        public static final char ExternalMarketParticipant                   = '8';
+        public static final char ActingAsMarketMakerOrSpecialistInUnderlying = '6';
+        public static final char ActingAsMarketMakerOrSpecialistInSecurity   = '5';
+        public static final char NonIndexArbitrage                           = '3';
+        public static final char IndexArbitrage                              = '2';
+        public static final char CompetingMarketMaker                        = '4';
+        public static final char ExternalInterConnectedMarketLinkage         = '9';
 
         private OrderRestrictionsValues() {
         }
@@ -2275,9 +2275,9 @@ public class FIX43Enumerations {
      */
     public static class ScopeValues {
 
-        public static final String LocalMarket = "1";
-        public static final String National    = "2";
-        public static final String Global      = "3";
+        public static final char LocalMarket = '1';
+        public static final char National    = '2';
+        public static final char Global      = '3';
 
         private ScopeValues() {
         }
@@ -2551,20 +2551,20 @@ public class FIX43Enumerations {
      */
     public static class ClearingFeeIndicatorValues {
 
-        public static final String Firms106HAnd106J              = "H";
-        public static final String FifthYearDelegate             = "5";
-        public static final String FourthYearDelegate            = "4";
-        public static final String ThirdYearDelegate             = "3";
-        public static final String SecondYearDelegate            = "2";
-        public static final String FirstYearDelegate             = "1";
-        public static final String AllOtherOwnershipTypes        = "M";
-        public static final String GIM                           = "I";
-        public static final String SixthYearDelegate             = "9";
-        public static final String FullAndAssociateMember        = "F";
-        public static final String EquityMemberAndClearingMember = "E";
-        public static final String NonMemberAndCustomer          = "C";
-        public static final String CBOEMember                    = "B";
-        public static final String Lessee106FEmployees           = "L";
+        public static final char Firms106HAnd106J              = 'H';
+        public static final char FifthYearDelegate             = '5';
+        public static final char FourthYearDelegate            = '4';
+        public static final char ThirdYearDelegate             = '3';
+        public static final char SecondYearDelegate            = '2';
+        public static final char FirstYearDelegate             = '1';
+        public static final char AllOtherOwnershipTypes        = 'M';
+        public static final char GIM                           = 'I';
+        public static final char SixthYearDelegate             = '9';
+        public static final char FullAndAssociateMember        = 'F';
+        public static final char EquityMemberAndClearingMember = 'E';
+        public static final char NonMemberAndCustomer          = 'C';
+        public static final char CBOEMember                    = 'B';
+        public static final char Lessee106FEmployees           = 'L';
 
         private ClearingFeeIndicatorValues() {
         }

--- a/libraries/fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44Enumerations.java
+++ b/libraries/fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44Enumerations.java
@@ -25,9 +25,9 @@ public class FIX44Enumerations {
      */
     public static class AdvTransTypeValues {
 
-        public static final String New     = "N";
-        public static final String Cancel  = "C";
-        public static final String Replace = "R";
+        public static final char New     = 'N';
+        public static final char Cancel  = 'C';
+        public static final char Replace = 'R';
 
         private AdvTransTypeValues() {
         }
@@ -56,46 +56,46 @@ public class FIX44Enumerations {
      */
     public static class ExecInstValues {
 
-        public static final String NotHeld                    = "1";
-        public static final String Work                       = "2";
-        public static final String GoAlong                    = "3";
-        public static final String OverTheDay                 = "4";
-        public static final String Held                       = "5";
-        public static final String ParticipateDoNotInitiate   = "6";
-        public static final String StrictScale                = "7";
-        public static final String TryToScale                 = "8";
-        public static final String StayOnBidSide              = "9";
-        public static final String StayOnOfferSide            = "0";
-        public static final String NoCross                    = "A";
-        public static final String OKToCross                  = "B";
-        public static final String CallFirst                  = "C";
-        public static final String PercentOfVolume            = "D";
-        public static final String DoNotIncrease              = "E";
-        public static final String DoNotReduce                = "F";
-        public static final String AllOrNone                  = "G";
-        public static final String ReinstateOnSystemFailure   = "H";
-        public static final String InstitutionsOnly           = "I";
-        public static final String ReinstateOnTradingHalt     = "J";
-        public static final String CancelOnTradingHalt        = "K";
-        public static final String LastPeg                    = "L";
-        public static final String MidPricePeg                = "M";
-        public static final String NonNegotiable              = "N";
-        public static final String OpeningPeg                 = "O";
-        public static final String MarketPeg                  = "P";
-        public static final String CancelOnSystemFailure      = "Q";
-        public static final String PrimaryPeg                 = "R";
-        public static final String Suspend                    = "S";
-        public static final String CustomerDisplayInstruction = "U";
-        public static final String Netting                    = "V";
-        public static final String PegToVWAP                  = "W";
-        public static final String TradeAlong                 = "X";
-        public static final String TryToStop                  = "Y";
-        public static final String CancelIfNotBest            = "Z";
-        public static final String TrailingStopPeg            = "a";
-        public static final String StrictLimit                = "b";
-        public static final String IgnorePriceValidityChecks  = "c";
-        public static final String PegToLimitPrice            = "d";
-        public static final String WorkToTargetStrategy       = "e";
+        public static final char NotHeld                    = '1';
+        public static final char Work                       = '2';
+        public static final char GoAlong                    = '3';
+        public static final char OverTheDay                 = '4';
+        public static final char Held                       = '5';
+        public static final char ParticipateDoNotInitiate   = '6';
+        public static final char StrictScale                = '7';
+        public static final char TryToScale                 = '8';
+        public static final char StayOnBidSide              = '9';
+        public static final char StayOnOfferSide            = '0';
+        public static final char NoCross                    = 'A';
+        public static final char OKToCross                  = 'B';
+        public static final char CallFirst                  = 'C';
+        public static final char PercentOfVolume            = 'D';
+        public static final char DoNotIncrease              = 'E';
+        public static final char DoNotReduce                = 'F';
+        public static final char AllOrNone                  = 'G';
+        public static final char ReinstateOnSystemFailure   = 'H';
+        public static final char InstitutionsOnly           = 'I';
+        public static final char ReinstateOnTradingHalt     = 'J';
+        public static final char CancelOnTradingHalt        = 'K';
+        public static final char LastPeg                    = 'L';
+        public static final char MidPricePeg                = 'M';
+        public static final char NonNegotiable              = 'N';
+        public static final char OpeningPeg                 = 'O';
+        public static final char MarketPeg                  = 'P';
+        public static final char CancelOnSystemFailure      = 'Q';
+        public static final char PrimaryPeg                 = 'R';
+        public static final char Suspend                    = 'S';
+        public static final char CustomerDisplayInstruction = 'U';
+        public static final char Netting                    = 'V';
+        public static final char PegToVWAP                  = 'W';
+        public static final char TradeAlong                 = 'X';
+        public static final char TryToStop                  = 'Y';
+        public static final char CancelIfNotBest            = 'Z';
+        public static final char TrailingStopPeg            = 'a';
+        public static final char StrictLimit                = 'b';
+        public static final char IgnorePriceValidityChecks  = 'c';
+        public static final char PegToLimitPrice            = 'd';
+        public static final char WorkToTargetStrategy       = 'e';
 
         private ExecInstValues() {
         }
@@ -121,25 +121,25 @@ public class FIX44Enumerations {
      */
     public static class SecurityIDSourceValues {
 
-        public static final String CUSIP                         = "1";
-        public static final String SEDOL                         = "2";
-        public static final String QUIK                          = "3";
-        public static final String ISINNumber                    = "4";
-        public static final String RICCode                       = "5";
-        public static final String ISOCurrencyCode               = "6";
-        public static final String ISOCountryCode                = "7";
-        public static final String ExchangeSymbol                = "8";
-        public static final String ConsolidatedTapeAssociation   = "9";
-        public static final String BloombergSymbol               = "A";
-        public static final String Wertpapier                    = "B";
-        public static final String Dutch                         = "C";
-        public static final String Valoren                       = "D";
-        public static final String Sicovam                       = "E";
-        public static final String Belgian                       = "F";
-        public static final String Common                        = "G";
-        public static final String ClearingHouse                 = "H";
-        public static final String ISDAFpMLSpecification         = "I";
-        public static final String OptionPriceReportingAuthority = "J";
+        public static final char CUSIP                         = '1';
+        public static final char SEDOL                         = '2';
+        public static final char QUIK                          = '3';
+        public static final char ISINNumber                    = '4';
+        public static final char RICCode                       = '5';
+        public static final char ISOCurrencyCode               = '6';
+        public static final char ISOCountryCode                = '7';
+        public static final char ExchangeSymbol                = '8';
+        public static final char ConsolidatedTapeAssociation   = '9';
+        public static final char BloombergSymbol               = 'A';
+        public static final char Wertpapier                    = 'B';
+        public static final char Dutch                         = 'C';
+        public static final char Valoren                       = 'D';
+        public static final char Sicovam                       = 'E';
+        public static final char Belgian                       = 'F';
+        public static final char Common                        = 'G';
+        public static final char ClearingHouse                 = 'H';
+        public static final char ISDAFpMLSpecification         = 'I';
+        public static final char OptionPriceReportingAuthority = 'J';
 
         private SecurityIDSourceValues() {
         }
@@ -165,9 +165,9 @@ public class FIX44Enumerations {
      */
     public static class IOIQtyValues {
 
-        public static final String Small  = "S";
-        public static final String Medium = "M";
-        public static final String Large  = "L";
+        public static final char Small  = 'S';
+        public static final char Medium = 'M';
+        public static final char Large  = 'L';
 
         private IOIQtyValues() {
         }
@@ -1040,15 +1040,15 @@ public class FIX44Enumerations {
      */
     public static class QuoteConditionValues {
 
-        public static final String Open             = "A";
-        public static final String Closed           = "B";
-        public static final String ExchangeBest     = "C";
-        public static final String ConsolidatedBest = "D";
-        public static final String Locked           = "E";
-        public static final String Crossed          = "F";
-        public static final String Depth            = "G";
-        public static final String FastTrading      = "H";
-        public static final String NonFirm          = "I";
+        public static final char Open             = 'A';
+        public static final char Closed           = 'B';
+        public static final char ExchangeBest     = 'C';
+        public static final char ConsolidatedBest = 'D';
+        public static final char Locked           = 'E';
+        public static final char Crossed          = 'F';
+        public static final char Depth            = 'G';
+        public static final char FastTrading      = 'H';
+        public static final char NonFirm          = 'I';
 
         private QuoteConditionValues() {
         }
@@ -1060,23 +1060,23 @@ public class FIX44Enumerations {
      */
     public static class TradeConditionValues {
 
-        public static final String Cash                 = "A";
-        public static final String AveragePriceTrade    = "B";
-        public static final String CashTrade            = "C";
-        public static final String NextDay              = "D";
-        public static final String Opening              = "E";
-        public static final String IntradayTradeDetail  = "F";
-        public static final String Rule127Trade         = "G";
-        public static final String Rule155Trade         = "H";
-        public static final String SoldLast             = "I";
-        public static final String NextDayTrade         = "J";
-        public static final String Opened               = "K";
-        public static final String Seller               = "L";
-        public static final String Sold                 = "M";
-        public static final String StoppedStock         = "N";
-        public static final String ImbalanceMoreBuyers  = "P";
-        public static final String ImbalanceMoreSellers = "Q";
-        public static final String OpeningPrice         = "R";
+        public static final char Cash                 = 'A';
+        public static final char AveragePriceTrade    = 'B';
+        public static final char CashTrade            = 'C';
+        public static final char NextDay              = 'D';
+        public static final char Opening              = 'E';
+        public static final char IntradayTradeDetail  = 'F';
+        public static final char Rule127Trade         = 'G';
+        public static final char Rule155Trade         = 'H';
+        public static final char SoldLast             = 'I';
+        public static final char NextDayTrade         = 'J';
+        public static final char Opened               = 'K';
+        public static final char Seller               = 'L';
+        public static final char Sold                 = 'M';
+        public static final char StoppedStock         = 'N';
+        public static final char ImbalanceMoreBuyers  = 'P';
+        public static final char ImbalanceMoreSellers = 'Q';
+        public static final char OpeningPrice         = 'R';
 
         private TradeConditionValues() {
         }
@@ -1139,12 +1139,12 @@ public class FIX44Enumerations {
      */
     public static class OpenCloseSettlFlagValues {
 
-        public static final String DailyOpen                    = "0";
-        public static final String SessionOpen                  = "1";
-        public static final String DeliverySettlementEntry      = "2";
-        public static final String ExpectedEntry                = "3";
-        public static final String EntryFromPreviousBusinessDay = "4";
-        public static final String TheoreticalPriceValue        = "5";
+        public static final char DailyOpen                    = '0';
+        public static final char SessionOpen                  = '1';
+        public static final char DeliverySettlementEntry      = '2';
+        public static final char ExpectedEntry                = '3';
+        public static final char EntryFromPreviousBusinessDay = '4';
+        public static final char TheoreticalPriceValue        = '5';
 
         private OpenCloseSettlFlagValues() {
         }
@@ -1156,8 +1156,8 @@ public class FIX44Enumerations {
      */
     public static class FinancialStatusValues {
 
-        public static final String Bankrupt         = "1";
-        public static final String PendingDelisting = "2";
+        public static final char Bankrupt         = '1';
+        public static final char PendingDelisting = '2';
 
         private FinancialStatusValues() {
         }
@@ -1169,11 +1169,11 @@ public class FIX44Enumerations {
      */
     public static class CorporateActionValues {
 
-        public static final String ExDividend     = "A";
-        public static final String ExDistribution = "B";
-        public static final String ExRights       = "C";
-        public static final String New            = "D";
-        public static final String ExInterest     = "E";
+        public static final char ExDividend     = 'A';
+        public static final char ExDistribution = 'B';
+        public static final char ExRights       = 'C';
+        public static final char New            = 'D';
+        public static final char ExInterest     = 'E';
 
         private CorporateActionValues() {
         }
@@ -2204,16 +2204,16 @@ public class FIX44Enumerations {
      */
     public static class OrderRestrictionsValues {
 
-        public static final String ProgramTrade                                = "1";
-        public static final String IndexArbitrage                              = "2";
-        public static final String NonIndexArbitrage                           = "3";
-        public static final String CompetingMarketMaker                        = "4";
-        public static final String ActingAsMarketMakerOrSpecialistInSecurity   = "5";
-        public static final String ActingAsMarketMakerOrSpecialistInUnderlying = "6";
-        public static final String ForeignEntity                               = "7";
-        public static final String ExternalMarketParticipant                   = "8";
-        public static final String ExternalInterConnectedMarketLinkage         = "9";
-        public static final String RisklessArbitrage                           = "A";
+        public static final char ProgramTrade                                = '1';
+        public static final char IndexArbitrage                              = '2';
+        public static final char NonIndexArbitrage                           = '3';
+        public static final char CompetingMarketMaker                        = '4';
+        public static final char ActingAsMarketMakerOrSpecialistInSecurity   = '5';
+        public static final char ActingAsMarketMakerOrSpecialistInUnderlying = '6';
+        public static final char ForeignEntity                               = '7';
+        public static final char ExternalMarketParticipant                   = '8';
+        public static final char ExternalInterConnectedMarketLinkage         = '9';
+        public static final char RisklessArbitrage                           = 'A';
 
         private OrderRestrictionsValues() {
         }
@@ -2310,9 +2310,9 @@ public class FIX44Enumerations {
      */
     public static class ScopeValues {
 
-        public static final String LocalMarket = "1";
-        public static final String National    = "2";
-        public static final String Global      = "3";
+        public static final char LocalMarket = '1';
+        public static final char National    = '2';
+        public static final char Global      = '3';
 
         private ScopeValues() {
         }
@@ -2619,20 +2619,20 @@ public class FIX44Enumerations {
      */
     public static class ClearingFeeIndicatorValues {
 
-        public static final String CBOEMember                    = "B";
-        public static final String NonMemberAndCustomer          = "C";
-        public static final String EquityMemberAndClearingMember = "E";
-        public static final String FullAndAssociateMember        = "F";
-        public static final String Firms106HAnd106J              = "H";
-        public static final String GIM                           = "I";
-        public static final String Lessee106FEmployees           = "L";
-        public static final String AllOtherOwnershipTypes        = "M";
-        public static final String FirstYearDelegate             = "1";
-        public static final String SecondYearDelegate            = "2";
-        public static final String ThirdYearDelegate             = "3";
-        public static final String FourthYearDelegate            = "4";
-        public static final String FifthYearDelegate             = "5";
-        public static final String SixthYearDelegate             = "9";
+        public static final char CBOEMember                    = 'B';
+        public static final char NonMemberAndCustomer          = 'C';
+        public static final char EquityMemberAndClearingMember = 'E';
+        public static final char FullAndAssociateMember        = 'F';
+        public static final char Firms106HAnd106J              = 'H';
+        public static final char GIM                           = 'I';
+        public static final char Lessee106FEmployees           = 'L';
+        public static final char AllOtherOwnershipTypes        = 'M';
+        public static final char FirstYearDelegate             = '1';
+        public static final char SecondYearDelegate            = '2';
+        public static final char ThirdYearDelegate             = '3';
+        public static final char FourthYearDelegate            = '4';
+        public static final char FifthYearDelegate             = '5';
+        public static final char SixthYearDelegate             = '9';
 
         private ClearingFeeIndicatorValues() {
         }

--- a/libraries/fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50Enumerations.java
+++ b/libraries/fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50Enumerations.java
@@ -25,9 +25,9 @@ public class FIX50Enumerations {
      */
     public static class AdvTransTypeValues {
 
-        public static final String New     = "N";
-        public static final String Cancel  = "C";
-        public static final String Replace = "R";
+        public static final char New     = 'N';
+        public static final char Cancel  = 'C';
+        public static final char Replace = 'R';
 
         private AdvTransTypeValues() {
         }
@@ -128,27 +128,27 @@ public class FIX50Enumerations {
      */
     public static class SecurityIDSourceValues {
 
-        public static final String CUSIP                         = "1";
-        public static final String SEDOL                         = "2";
-        public static final String QUIK                          = "3";
-        public static final String ISINNumber                    = "4";
-        public static final String RICCode                       = "5";
-        public static final String ISOCurrencyCode               = "6";
-        public static final String ISOCountryCode                = "7";
-        public static final String ExchangeSymbol                = "8";
-        public static final String ConsolidatedTapeAssociation   = "9";
-        public static final String BloombergSymbol               = "A";
-        public static final String Wertpapier                    = "B";
-        public static final String Dutch                         = "C";
-        public static final String Valoren                       = "D";
-        public static final String Sicovam                       = "E";
-        public static final String Belgian                       = "F";
-        public static final String Common                        = "G";
-        public static final String ClearingHouse                 = "H";
-        public static final String ISDAFpMLSpecification         = "I";
-        public static final String OptionPriceReportingAuthority = "J";
-        public static final String ISDAFpMLURL                   = "K";
-        public static final String LetterOfCredit                = "L";
+        public static final char CUSIP                         = '1';
+        public static final char SEDOL                         = '2';
+        public static final char QUIK                          = '3';
+        public static final char ISINNumber                    = '4';
+        public static final char RICCode                       = '5';
+        public static final char ISOCurrencyCode               = '6';
+        public static final char ISOCountryCode                = '7';
+        public static final char ExchangeSymbol                = '8';
+        public static final char ConsolidatedTapeAssociation   = '9';
+        public static final char BloombergSymbol               = 'A';
+        public static final char Wertpapier                    = 'B';
+        public static final char Dutch                         = 'C';
+        public static final char Valoren                       = 'D';
+        public static final char Sicovam                       = 'E';
+        public static final char Belgian                       = 'F';
+        public static final char Common                        = 'G';
+        public static final char ClearingHouse                 = 'H';
+        public static final char ISDAFpMLSpecification         = 'I';
+        public static final char OptionPriceReportingAuthority = 'J';
+        public static final char ISDAFpMLURL                   = 'K';
+        public static final char LetterOfCredit                = 'L';
 
         private SecurityIDSourceValues() {
         }
@@ -174,10 +174,10 @@ public class FIX50Enumerations {
      */
     public static class IOIQtyValues {
 
-        public static final String Small               = "S";
-        public static final String Medium              = "M";
-        public static final String Large               = "L";
-        public static final String UndisclosedQuantity = "U";
+        public static final char Small               = 'S';
+        public static final char Medium              = 'M';
+        public static final char Large               = 'L';
+        public static final char UndisclosedQuantity = 'U';
 
         private IOIQtyValues() {
         }
@@ -339,18 +339,18 @@ public class FIX50Enumerations {
      */
     public static class SettlTypeValues {
 
-        public static final String Regular              = "0";
-        public static final String Cash                 = "1";
-        public static final String NextDay              = "2";
-        public static final String TPlus2               = "3";
-        public static final String TPlus3               = "4";
-        public static final String TPlus4               = "5";
-        public static final String Future               = "6";
-        public static final String WhenAndIfIssued      = "7";
-        public static final String SellersOption        = "8";
-        public static final String TPlus5               = "9";
-        public static final String BrokenDate           = "B";
-        public static final String FXSpotNextSettlement = "C";
+        public static final char Regular              = '0';
+        public static final char Cash                 = '1';
+        public static final char NextDay              = '2';
+        public static final char TPlus2               = '3';
+        public static final char TPlus3               = '4';
+        public static final char TPlus4               = '5';
+        public static final char Future               = '6';
+        public static final char WhenAndIfIssued      = '7';
+        public static final char SellersOption        = '8';
+        public static final char TPlus5               = '9';
+        public static final char BrokenDate           = 'B';
+        public static final char FXSpotNextSettlement = 'C';
 
         private SettlTypeValues() {
         }
@@ -1140,61 +1140,61 @@ public class FIX50Enumerations {
      */
     public static class QuoteConditionValues {
 
-        public static final String Open                       = "A";
-        public static final String Closed                     = "B";
-        public static final String ExchangeBest               = "C";
-        public static final String ConsolidatedBest           = "D";
-        public static final String Locked                     = "E";
-        public static final String Crossed                    = "F";
-        public static final String Depth                      = "G";
-        public static final String FastTrading                = "H";
-        public static final String NonFirm                    = "I";
-        public static final String Manual                     = "L";
-        public static final String OutrightPrice              = "J";
-        public static final String ImpliedPrice               = "K";
-        public static final String DepthOnOffer               = "M";
-        public static final String DepthOnBid                 = "N";
-        public static final String Closing                    = "O";
-        public static final String NewsDissemination          = "P";
-        public static final String TradingRange               = "Q";
-        public static final String OrderInflux                = "R";
-        public static final String DueToRelated               = "S";
-        public static final String NewsPending                = "T";
-        public static final String AdditionalInfo             = "U";
-        public static final String AdditionalInfoDueToRelated = "V";
-        public static final String Resume                     = "W";
-        public static final String ViewOfCommon               = "X";
-        public static final String VolumeAlert                = "Y";
-        public static final String OrderImbalance             = "Z";
-        public static final String EquipmentChangeover        = "a";
-        public static final String NoOpen                     = "b";
-        public static final String RegularETH                 = "c";
-        public static final String AutomaticExecution         = "d";
-        public static final String AutomaticExecutionETH      = "e";
-        public static final String FastMarketETH              = "f";
-        public static final String InactiveETH                = "g";
-        public static final String Rotation                   = "h";
-        public static final String RotationETH                = "i";
-        public static final String Halt                       = "j";
-        public static final String HaltETH                    = "k";
-        public static final String DueToNewsDissemination     = "l";
-        public static final String DueToNewsPending           = "m";
-        public static final String TradingResume              = "n";
-        public static final String OutOfSequence              = "o";
-        public static final String BidSpecialist              = "p";
-        public static final String OfferSpecialist            = "q";
-        public static final String BidOfferSpecialist         = "r";
-        public static final String EndOfDaySAM                = "s";
-        public static final String ForbiddenSAM               = "t";
-        public static final String FrozenSAM                  = "u";
-        public static final String PreOpeningSAM              = "v";
-        public static final String OpeningSAM                 = "w";
-        public static final String OpenSAM                    = "x";
-        public static final String SurveillanceSAM            = "y";
-        public static final String SuspendedSAM               = "z";
-        public static final String ReservedSAM                = "0";
-        public static final String NoActiveSAM                = "1";
-        public static final String Restricted                 = "2";
+        public static final char Open                       = 'A';
+        public static final char Closed                     = 'B';
+        public static final char ExchangeBest               = 'C';
+        public static final char ConsolidatedBest           = 'D';
+        public static final char Locked                     = 'E';
+        public static final char Crossed                    = 'F';
+        public static final char Depth                      = 'G';
+        public static final char FastTrading                = 'H';
+        public static final char NonFirm                    = 'I';
+        public static final char Manual                     = 'L';
+        public static final char OutrightPrice              = 'J';
+        public static final char ImpliedPrice               = 'K';
+        public static final char DepthOnOffer               = 'M';
+        public static final char DepthOnBid                 = 'N';
+        public static final char Closing                    = 'O';
+        public static final char NewsDissemination          = 'P';
+        public static final char TradingRange               = 'Q';
+        public static final char OrderInflux                = 'R';
+        public static final char DueToRelated               = 'S';
+        public static final char NewsPending                = 'T';
+        public static final char AdditionalInfo             = 'U';
+        public static final char AdditionalInfoDueToRelated = 'V';
+        public static final char Resume                     = 'W';
+        public static final char ViewOfCommon               = 'X';
+        public static final char VolumeAlert                = 'Y';
+        public static final char OrderImbalance             = 'Z';
+        public static final char EquipmentChangeover        = 'a';
+        public static final char NoOpen                     = 'b';
+        public static final char RegularETH                 = 'c';
+        public static final char AutomaticExecution         = 'd';
+        public static final char AutomaticExecutionETH      = 'e';
+        public static final char FastMarketETH              = 'f';
+        public static final char InactiveETH                = 'g';
+        public static final char Rotation                   = 'h';
+        public static final char RotationETH                = 'i';
+        public static final char Halt                       = 'j';
+        public static final char HaltETH                    = 'k';
+        public static final char DueToNewsDissemination     = 'l';
+        public static final char DueToNewsPending           = 'm';
+        public static final char TradingResume              = 'n';
+        public static final char OutOfSequence              = 'o';
+        public static final char BidSpecialist              = 'p';
+        public static final char OfferSpecialist            = 'q';
+        public static final char BidOfferSpecialist         = 'r';
+        public static final char EndOfDaySAM                = 's';
+        public static final char ForbiddenSAM               = 't';
+        public static final char FrozenSAM                  = 'u';
+        public static final char PreOpeningSAM              = 'v';
+        public static final char OpeningSAM                 = 'w';
+        public static final char OpenSAM                    = 'x';
+        public static final char SurveillanceSAM            = 'y';
+        public static final char SuspendedSAM               = 'z';
+        public static final char ReservedSAM                = '0';
+        public static final char NoActiveSAM                = '1';
+        public static final char Restricted                 = '2';
 
         private QuoteConditionValues() {
         }
@@ -2919,20 +2919,20 @@ public class FIX50Enumerations {
      */
     public static class ClearingFeeIndicatorValues {
 
-        public static final String FirstYearDelegate             = "1";
-        public static final String SecondYearDelegate            = "2";
-        public static final String ThirdYearDelegate             = "3";
-        public static final String FourthYearDelegate            = "4";
-        public static final String FifthYearDelegate             = "5";
-        public static final String SixthYearDelegate             = "9";
-        public static final String CBOEMember                    = "B";
-        public static final String NonMemberAndCustomer          = "C";
-        public static final String EquityMemberAndClearingMember = "E";
-        public static final String FullAndAssociateMember        = "F";
-        public static final String Firms106HAnd106J              = "H";
-        public static final String GIM                           = "I";
-        public static final String Lessee106FEmployees           = "L";
-        public static final String AllOtherOwnershipTypes        = "M";
+        public static final char FirstYearDelegate             = '1';
+        public static final char SecondYearDelegate            = '2';
+        public static final char ThirdYearDelegate             = '3';
+        public static final char FourthYearDelegate            = '4';
+        public static final char FifthYearDelegate             = '5';
+        public static final char SixthYearDelegate             = '9';
+        public static final char CBOEMember                    = 'B';
+        public static final char NonMemberAndCustomer          = 'C';
+        public static final char EquityMemberAndClearingMember = 'E';
+        public static final char FullAndAssociateMember        = 'F';
+        public static final char Firms106HAnd106J              = 'H';
+        public static final char GIM                           = 'I';
+        public static final char Lessee106FEmployees           = 'L';
+        public static final char AllOtherOwnershipTypes        = 'M';
 
         private ClearingFeeIndicatorValues() {
         }
@@ -4450,8 +4450,8 @@ public class FIX50Enumerations {
      */
     public static class SecurityStatusValues {
 
-        public static final String Active   = "1";
-        public static final String Inactive = "2";
+        public static final char Active   = '1';
+        public static final char Inactive = '2';
 
         private SecurityStatusValues() {
         }
@@ -5042,14 +5042,14 @@ public class FIX50Enumerations {
      */
     public static class ApplVerIDValues {
 
-        public static final String FIX27 = "0";
-        public static final String FIX30 = "1";
-        public static final String FIX40 = "2";
-        public static final String FIX41 = "3";
-        public static final String FIX42 = "4";
-        public static final String FIX43 = "5";
-        public static final String FIX44 = "6";
-        public static final String FIX50 = "7";
+        public static final char FIX27 = '0';
+        public static final char FIX30 = '1';
+        public static final char FIX40 = '2';
+        public static final char FIX41 = '3';
+        public static final char FIX42 = '4';
+        public static final char FIX43 = '5';
+        public static final char FIX44 = '6';
+        public static final char FIX50 = '7';
 
         private ApplVerIDValues() {
         }

--- a/libraries/fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1Enumerations.java
+++ b/libraries/fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1Enumerations.java
@@ -25,9 +25,9 @@ public class FIX50SP1Enumerations {
      */
     public static class AdvTransTypeValues {
 
-        public static final String New     = "N";
-        public static final String Cancel  = "C";
-        public static final String Replace = "R";
+        public static final char New     = 'N';
+        public static final char Cancel  = 'C';
+        public static final char Replace = 'R';
 
         private AdvTransTypeValues() {
         }
@@ -137,28 +137,28 @@ public class FIX50SP1Enumerations {
      */
     public static class SecurityIDSourceValues {
 
-        public static final String CUSIP                         = "1";
-        public static final String SEDOL                         = "2";
-        public static final String QUIK                          = "3";
-        public static final String ISINNumber                    = "4";
-        public static final String RICCode                       = "5";
-        public static final String ISOCurrencyCode               = "6";
-        public static final String ISOCountryCode                = "7";
-        public static final String ExchangeSymbol                = "8";
-        public static final String ConsolidatedTapeAssociation   = "9";
-        public static final String BloombergSymbol               = "A";
-        public static final String Wertpapier                    = "B";
-        public static final String Dutch                         = "C";
-        public static final String Valoren                       = "D";
-        public static final String Sicovam                       = "E";
-        public static final String Belgian                       = "F";
-        public static final String Common                        = "G";
-        public static final String ClearingHouse                 = "H";
-        public static final String ISDAFpMLSpecification         = "I";
-        public static final String OptionPriceReportingAuthority = "J";
-        public static final String ISDAFpMLURL                   = "K";
-        public static final String LetterOfCredit                = "L";
-        public static final String MarketplaceAssignedIdentifier = "M";
+        public static final char CUSIP                         = '1';
+        public static final char SEDOL                         = '2';
+        public static final char QUIK                          = '3';
+        public static final char ISINNumber                    = '4';
+        public static final char RICCode                       = '5';
+        public static final char ISOCurrencyCode               = '6';
+        public static final char ISOCountryCode                = '7';
+        public static final char ExchangeSymbol                = '8';
+        public static final char ConsolidatedTapeAssociation   = '9';
+        public static final char BloombergSymbol               = 'A';
+        public static final char Wertpapier                    = 'B';
+        public static final char Dutch                         = 'C';
+        public static final char Valoren                       = 'D';
+        public static final char Sicovam                       = 'E';
+        public static final char Belgian                       = 'F';
+        public static final char Common                        = 'G';
+        public static final char ClearingHouse                 = 'H';
+        public static final char ISDAFpMLSpecification         = 'I';
+        public static final char OptionPriceReportingAuthority = 'J';
+        public static final char ISDAFpMLURL                   = 'K';
+        public static final char LetterOfCredit                = 'L';
+        public static final char MarketplaceAssignedIdentifier = 'M';
 
         private SecurityIDSourceValues() {
         }
@@ -184,10 +184,10 @@ public class FIX50SP1Enumerations {
      */
     public static class IOIQtyValues {
 
-        public static final String Small               = "S";
-        public static final String Medium              = "M";
-        public static final String Large               = "L";
-        public static final String UndisclosedQuantity = "U";
+        public static final char Small               = 'S';
+        public static final char Medium              = 'M';
+        public static final char Large               = 'L';
+        public static final char UndisclosedQuantity = 'U';
 
         private IOIQtyValues() {
         }
@@ -351,18 +351,18 @@ public class FIX50SP1Enumerations {
      */
     public static class SettlTypeValues {
 
-        public static final String Regular              = "0";
-        public static final String Cash                 = "1";
-        public static final String NextDay              = "2";
-        public static final String TPlus2               = "3";
-        public static final String TPlus3               = "4";
-        public static final String TPlus4               = "5";
-        public static final String Future               = "6";
-        public static final String WhenAndIfIssued      = "7";
-        public static final String SellersOption        = "8";
-        public static final String TPlus5               = "9";
-        public static final String BrokenDate           = "B";
-        public static final String FXSpotNextSettlement = "C";
+        public static final char Regular              = '0';
+        public static final char Cash                 = '1';
+        public static final char NextDay              = '2';
+        public static final char TPlus2               = '3';
+        public static final char TPlus3               = '4';
+        public static final char TPlus4               = '5';
+        public static final char Future               = '6';
+        public static final char WhenAndIfIssued      = '7';
+        public static final char SellersOption        = '8';
+        public static final char TPlus5               = '9';
+        public static final char BrokenDate           = 'B';
+        public static final char FXSpotNextSettlement = 'C';
 
         private SettlTypeValues() {
         }
@@ -1197,64 +1197,64 @@ public class FIX50SP1Enumerations {
      */
     public static class QuoteConditionValues {
 
-        public static final String Open                            = "A";
-        public static final String Closed                          = "B";
-        public static final String ExchangeBest                    = "C";
-        public static final String ConsolidatedBest                = "D";
-        public static final String Locked                          = "E";
-        public static final String Crossed                         = "F";
-        public static final String Depth                           = "G";
-        public static final String FastTrading                     = "H";
-        public static final String NonFirm                         = "I";
-        public static final String Manual                          = "L";
-        public static final String OutrightPrice                   = "J";
-        public static final String ImpliedPrice                    = "K";
-        public static final String DepthOnOffer                    = "M";
-        public static final String DepthOnBid                      = "N";
-        public static final String Closing                         = "O";
-        public static final String NewsDissemination               = "P";
-        public static final String TradingRange                    = "Q";
-        public static final String OrderInflux                     = "R";
-        public static final String DueToRelated                    = "S";
-        public static final String NewsPending                     = "T";
-        public static final String AdditionalInfo                  = "U";
-        public static final String AdditionalInfoDueToRelated      = "V";
-        public static final String Resume                          = "W";
-        public static final String ViewOfCommon                    = "X";
-        public static final String VolumeAlert                     = "Y";
-        public static final String OrderImbalance                  = "Z";
-        public static final String EquipmentChangeover             = "a";
-        public static final String NoOpen                          = "b";
-        public static final String RegularETH                      = "c";
-        public static final String AutomaticExecution              = "d";
-        public static final String AutomaticExecutionETH           = "e";
-        public static final String FastMarketETH                   = "f";
-        public static final String InactiveETH                     = "g";
-        public static final String Rotation                        = "h";
-        public static final String RotationETH                     = "i";
-        public static final String Halt                            = "j";
-        public static final String HaltETH                         = "k";
-        public static final String DueToNewsDissemination          = "l";
-        public static final String DueToNewsPending                = "m";
-        public static final String TradingResume                   = "n";
-        public static final String OutOfSequence                   = "o";
-        public static final String BidSpecialist                   = "p";
-        public static final String OfferSpecialist                 = "q";
-        public static final String BidOfferSpecialist              = "r";
-        public static final String EndOfDaySAM                     = "s";
-        public static final String ForbiddenSAM                    = "t";
-        public static final String FrozenSAM                       = "u";
-        public static final String PreOpeningSAM                   = "v";
-        public static final String OpeningSAM                      = "w";
-        public static final String OpenSAM                         = "x";
-        public static final String SurveillanceSAM                 = "y";
-        public static final String SuspendedSAM                    = "z";
-        public static final String ReservedSAM                     = "0";
-        public static final String NoActiveSAM                     = "1";
-        public static final String Restricted                      = "2";
-        public static final String RestOfBookVWAP                  = "3";
-        public static final String BetterPricesInConditionalOrders = "4";
-        public static final String MedianPrice                     = "5";
+        public static final char Open                            = 'A';
+        public static final char Closed                          = 'B';
+        public static final char ExchangeBest                    = 'C';
+        public static final char ConsolidatedBest                = 'D';
+        public static final char Locked                          = 'E';
+        public static final char Crossed                         = 'F';
+        public static final char Depth                           = 'G';
+        public static final char FastTrading                     = 'H';
+        public static final char NonFirm                         = 'I';
+        public static final char Manual                          = 'L';
+        public static final char OutrightPrice                   = 'J';
+        public static final char ImpliedPrice                    = 'K';
+        public static final char DepthOnOffer                    = 'M';
+        public static final char DepthOnBid                      = 'N';
+        public static final char Closing                         = 'O';
+        public static final char NewsDissemination               = 'P';
+        public static final char TradingRange                    = 'Q';
+        public static final char OrderInflux                     = 'R';
+        public static final char DueToRelated                    = 'S';
+        public static final char NewsPending                     = 'T';
+        public static final char AdditionalInfo                  = 'U';
+        public static final char AdditionalInfoDueToRelated      = 'V';
+        public static final char Resume                          = 'W';
+        public static final char ViewOfCommon                    = 'X';
+        public static final char VolumeAlert                     = 'Y';
+        public static final char OrderImbalance                  = 'Z';
+        public static final char EquipmentChangeover             = 'a';
+        public static final char NoOpen                          = 'b';
+        public static final char RegularETH                      = 'c';
+        public static final char AutomaticExecution              = 'd';
+        public static final char AutomaticExecutionETH           = 'e';
+        public static final char FastMarketETH                   = 'f';
+        public static final char InactiveETH                     = 'g';
+        public static final char Rotation                        = 'h';
+        public static final char RotationETH                     = 'i';
+        public static final char Halt                            = 'j';
+        public static final char HaltETH                         = 'k';
+        public static final char DueToNewsDissemination          = 'l';
+        public static final char DueToNewsPending                = 'm';
+        public static final char TradingResume                   = 'n';
+        public static final char OutOfSequence                   = 'o';
+        public static final char BidSpecialist                   = 'p';
+        public static final char OfferSpecialist                 = 'q';
+        public static final char BidOfferSpecialist              = 'r';
+        public static final char EndOfDaySAM                     = 's';
+        public static final char ForbiddenSAM                    = 't';
+        public static final char FrozenSAM                       = 'u';
+        public static final char PreOpeningSAM                   = 'v';
+        public static final char OpeningSAM                      = 'w';
+        public static final char OpenSAM                         = 'x';
+        public static final char SurveillanceSAM                 = 'y';
+        public static final char SuspendedSAM                    = 'z';
+        public static final char ReservedSAM                     = '0';
+        public static final char NoActiveSAM                     = '1';
+        public static final char Restricted                      = '2';
+        public static final char RestOfBookVWAP                  = '3';
+        public static final char BetterPricesInConditionalOrders = '4';
+        public static final char MedianPrice                     = '5';
 
         private QuoteConditionValues() {
         }
@@ -1677,12 +1677,12 @@ public class FIX50SP1Enumerations {
      */
     public static class TradingSessionIDValues {
 
-        public static final String Day        = "1";
-        public static final String HalfDay    = "2";
-        public static final String Morning    = "3";
-        public static final String Afternoon  = "4";
-        public static final String Evening    = "5";
-        public static final String AfterHours = "6";
+        public static final char Day        = '1';
+        public static final char HalfDay    = '2';
+        public static final char Morning    = '3';
+        public static final char Afternoon  = '4';
+        public static final char Evening    = '5';
+        public static final char AfterHours = '6';
 
         private TradingSessionIDValues() {
         }
@@ -3007,13 +3007,13 @@ public class FIX50SP1Enumerations {
      */
     public static class TradingSessionSubIDValues {
 
-        public static final String PreTrading              = "1";
-        public static final String OpeningOrOpeningAuction = "2";
-        public static final String Continuous              = "3";
-        public static final String ClosingOrClosingAuction = "4";
-        public static final String PostTrading             = "5";
-        public static final String IntradayAuction         = "6";
-        public static final String Quiescent               = "7";
+        public static final char PreTrading              = '1';
+        public static final char OpeningOrOpeningAuction = '2';
+        public static final char Continuous              = '3';
+        public static final char ClosingOrClosingAuction = '4';
+        public static final char PostTrading             = '5';
+        public static final char IntradayAuction         = '6';
+        public static final char Quiescent               = '7';
 
         private TradingSessionSubIDValues() {
         }
@@ -3050,20 +3050,20 @@ public class FIX50SP1Enumerations {
      */
     public static class ClearingFeeIndicatorValues {
 
-        public static final String FirstYearDelegate             = "1";
-        public static final String SecondYearDelegate            = "2";
-        public static final String ThirdYearDelegate             = "3";
-        public static final String FourthYearDelegate            = "4";
-        public static final String FifthYearDelegate             = "5";
-        public static final String SixthYearDelegate             = "9";
-        public static final String CBOEMember                    = "B";
-        public static final String NonMemberAndCustomer          = "C";
-        public static final String EquityMemberAndClearingMember = "E";
-        public static final String FullAndAssociateMember        = "F";
-        public static final String Firms106HAnd106J              = "H";
-        public static final String GIM                           = "I";
-        public static final String Lessee106FEmployees           = "L";
-        public static final String AllOtherOwnershipTypes        = "M";
+        public static final char FirstYearDelegate             = '1';
+        public static final char SecondYearDelegate            = '2';
+        public static final char ThirdYearDelegate             = '3';
+        public static final char FourthYearDelegate            = '4';
+        public static final char FifthYearDelegate             = '5';
+        public static final char SixthYearDelegate             = '9';
+        public static final char CBOEMember                    = 'B';
+        public static final char NonMemberAndCustomer          = 'C';
+        public static final char EquityMemberAndClearingMember = 'E';
+        public static final char FullAndAssociateMember        = 'F';
+        public static final char Firms106HAnd106J              = 'H';
+        public static final char GIM                           = 'I';
+        public static final char Lessee106FEmployees           = 'L';
+        public static final char AllOtherOwnershipTypes        = 'M';
 
         private ClearingFeeIndicatorValues() {
         }
@@ -4624,8 +4624,8 @@ public class FIX50SP1Enumerations {
      */
     public static class SecurityStatusValues {
 
-        public static final String Active   = "1";
-        public static final String Inactive = "2";
+        public static final char Active   = '1';
+        public static final char Inactive = '2';
 
         private SecurityStatusValues() {
         }
@@ -5217,15 +5217,15 @@ public class FIX50SP1Enumerations {
      */
     public static class ApplVerIDValues {
 
-        public static final String FIX27    = "0";
-        public static final String FIX30    = "1";
-        public static final String FIX40    = "2";
-        public static final String FIX41    = "3";
-        public static final String FIX42    = "4";
-        public static final String FIX43    = "5";
-        public static final String FIX44    = "6";
-        public static final String FIX50    = "7";
-        public static final String FIX50SP1 = "8";
+        public static final char FIX27    = '0';
+        public static final char FIX30    = '1';
+        public static final char FIX40    = '2';
+        public static final char FIX41    = '3';
+        public static final char FIX42    = '4';
+        public static final char FIX43    = '5';
+        public static final char FIX44    = '6';
+        public static final char FIX50    = '7';
+        public static final char FIX50SP1 = '8';
 
         private ApplVerIDValues() {
         }

--- a/libraries/fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2Enumerations.java
+++ b/libraries/fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2Enumerations.java
@@ -25,9 +25,9 @@ public class FIX50SP2Enumerations {
      */
     public static class AdvTransTypeValues {
 
-        public static final String New     = "N";
-        public static final String Cancel  = "C";
-        public static final String Replace = "R";
+        public static final char New     = 'N';
+        public static final char Cancel  = 'C';
+        public static final char Replace = 'R';
 
         private AdvTransTypeValues() {
         }
@@ -137,28 +137,28 @@ public class FIX50SP2Enumerations {
      */
     public static class SecurityIDSourceValues {
 
-        public static final String CUSIP                         = "1";
-        public static final String SEDOL                         = "2";
-        public static final String QUIK                          = "3";
-        public static final String ISINNumber                    = "4";
-        public static final String RICCode                       = "5";
-        public static final String ISOCurrencyCode               = "6";
-        public static final String ISOCountryCode                = "7";
-        public static final String ExchangeSymbol                = "8";
-        public static final String ConsolidatedTapeAssociation   = "9";
-        public static final String BloombergSymbol               = "A";
-        public static final String Wertpapier                    = "B";
-        public static final String Dutch                         = "C";
-        public static final String Valoren                       = "D";
-        public static final String Sicovam                       = "E";
-        public static final String Belgian                       = "F";
-        public static final String Common                        = "G";
-        public static final String ClearingHouse                 = "H";
-        public static final String ISDAFpMLSpecification         = "I";
-        public static final String OptionPriceReportingAuthority = "J";
-        public static final String ISDAFpMLURL                   = "K";
-        public static final String LetterOfCredit                = "L";
-        public static final String MarketplaceAssignedIdentifier = "M";
+        public static final char CUSIP                         = '1';
+        public static final char SEDOL                         = '2';
+        public static final char QUIK                          = '3';
+        public static final char ISINNumber                    = '4';
+        public static final char RICCode                       = '5';
+        public static final char ISOCurrencyCode               = '6';
+        public static final char ISOCountryCode                = '7';
+        public static final char ExchangeSymbol                = '8';
+        public static final char ConsolidatedTapeAssociation   = '9';
+        public static final char BloombergSymbol               = 'A';
+        public static final char Wertpapier                    = 'B';
+        public static final char Dutch                         = 'C';
+        public static final char Valoren                       = 'D';
+        public static final char Sicovam                       = 'E';
+        public static final char Belgian                       = 'F';
+        public static final char Common                        = 'G';
+        public static final char ClearingHouse                 = 'H';
+        public static final char ISDAFpMLSpecification         = 'I';
+        public static final char OptionPriceReportingAuthority = 'J';
+        public static final char ISDAFpMLURL                   = 'K';
+        public static final char LetterOfCredit                = 'L';
+        public static final char MarketplaceAssignedIdentifier = 'M';
 
         private SecurityIDSourceValues() {
         }
@@ -184,10 +184,10 @@ public class FIX50SP2Enumerations {
      */
     public static class IOIQtyValues {
 
-        public static final String Small               = "S";
-        public static final String Medium              = "M";
-        public static final String Large               = "L";
-        public static final String UndisclosedQuantity = "U";
+        public static final char Small               = 'S';
+        public static final char Medium              = 'M';
+        public static final char Large               = 'L';
+        public static final char UndisclosedQuantity = 'U';
 
         private IOIQtyValues() {
         }
@@ -351,18 +351,18 @@ public class FIX50SP2Enumerations {
      */
     public static class SettlTypeValues {
 
-        public static final String Regular              = "0";
-        public static final String Cash                 = "1";
-        public static final String NextDay              = "2";
-        public static final String TPlus2               = "3";
-        public static final String TPlus3               = "4";
-        public static final String TPlus4               = "5";
-        public static final String Future               = "6";
-        public static final String WhenAndIfIssued      = "7";
-        public static final String SellersOption        = "8";
-        public static final String TPlus5               = "9";
-        public static final String BrokenDate           = "B";
-        public static final String FXSpotNextSettlement = "C";
+        public static final char Regular              = '0';
+        public static final char Cash                 = '1';
+        public static final char NextDay              = '2';
+        public static final char TPlus2               = '3';
+        public static final char TPlus3               = '4';
+        public static final char TPlus4               = '5';
+        public static final char Future               = '6';
+        public static final char WhenAndIfIssued      = '7';
+        public static final char SellersOption        = '8';
+        public static final char TPlus5               = '9';
+        public static final char BrokenDate           = 'B';
+        public static final char FXSpotNextSettlement = 'C';
 
         private SettlTypeValues() {
         }
@@ -1207,66 +1207,66 @@ public class FIX50SP2Enumerations {
      */
     public static class QuoteConditionValues {
 
-        public static final String Open                            = "A";
-        public static final String Closed                          = "B";
-        public static final String ExchangeBest                    = "C";
-        public static final String ConsolidatedBest                = "D";
-        public static final String Locked                          = "E";
-        public static final String Crossed                         = "F";
-        public static final String Depth                           = "G";
-        public static final String FastTrading                     = "H";
-        public static final String NonFirm                         = "I";
-        public static final String Manual                          = "L";
-        public static final String OutrightPrice                   = "J";
-        public static final String ImpliedPrice                    = "K";
-        public static final String DepthOnOffer                    = "M";
-        public static final String DepthOnBid                      = "N";
-        public static final String Closing                         = "O";
-        public static final String NewsDissemination               = "P";
-        public static final String TradingRange                    = "Q";
-        public static final String OrderInflux                     = "R";
-        public static final String DueToRelated                    = "S";
-        public static final String NewsPending                     = "T";
-        public static final String AdditionalInfo                  = "U";
-        public static final String AdditionalInfoDueToRelated      = "V";
-        public static final String Resume                          = "W";
-        public static final String ViewOfCommon                    = "X";
-        public static final String VolumeAlert                     = "Y";
-        public static final String OrderImbalance                  = "Z";
-        public static final String EquipmentChangeover             = "a";
-        public static final String NoOpen                          = "b";
-        public static final String RegularETH                      = "c";
-        public static final String AutomaticExecution              = "d";
-        public static final String AutomaticExecutionETH           = "e";
-        public static final String FastMarketETH                   = "f";
-        public static final String InactiveETH                     = "g";
-        public static final String Rotation                        = "h";
-        public static final String RotationETH                     = "i";
-        public static final String Halt                            = "j";
-        public static final String HaltETH                         = "k";
-        public static final String DueToNewsDissemination          = "l";
-        public static final String DueToNewsPending                = "m";
-        public static final String TradingResume                   = "n";
-        public static final String OutOfSequence                   = "o";
-        public static final String BidSpecialist                   = "p";
-        public static final String OfferSpecialist                 = "q";
-        public static final String BidOfferSpecialist              = "r";
-        public static final String EndOfDaySAM                     = "s";
-        public static final String ForbiddenSAM                    = "t";
-        public static final String FrozenSAM                       = "u";
-        public static final String PreOpeningSAM                   = "v";
-        public static final String OpeningSAM                      = "w";
-        public static final String OpenSAM                         = "x";
-        public static final String SurveillanceSAM                 = "y";
-        public static final String SuspendedSAM                    = "z";
-        public static final String ReservedSAM                     = "0";
-        public static final String NoActiveSAM                     = "1";
-        public static final String Restricted                      = "2";
-        public static final String RestOfBookVWAP                  = "3";
-        public static final String BetterPricesInConditionalOrders = "4";
-        public static final String MedianPrice                     = "5";
-        public static final String FullCurve                       = "6";
-        public static final String FlatCurve                       = "7";
+        public static final char Open                            = 'A';
+        public static final char Closed                          = 'B';
+        public static final char ExchangeBest                    = 'C';
+        public static final char ConsolidatedBest                = 'D';
+        public static final char Locked                          = 'E';
+        public static final char Crossed                         = 'F';
+        public static final char Depth                           = 'G';
+        public static final char FastTrading                     = 'H';
+        public static final char NonFirm                         = 'I';
+        public static final char Manual                          = 'L';
+        public static final char OutrightPrice                   = 'J';
+        public static final char ImpliedPrice                    = 'K';
+        public static final char DepthOnOffer                    = 'M';
+        public static final char DepthOnBid                      = 'N';
+        public static final char Closing                         = 'O';
+        public static final char NewsDissemination               = 'P';
+        public static final char TradingRange                    = 'Q';
+        public static final char OrderInflux                     = 'R';
+        public static final char DueToRelated                    = 'S';
+        public static final char NewsPending                     = 'T';
+        public static final char AdditionalInfo                  = 'U';
+        public static final char AdditionalInfoDueToRelated      = 'V';
+        public static final char Resume                          = 'W';
+        public static final char ViewOfCommon                    = 'X';
+        public static final char VolumeAlert                     = 'Y';
+        public static final char OrderImbalance                  = 'Z';
+        public static final char EquipmentChangeover             = 'a';
+        public static final char NoOpen                          = 'b';
+        public static final char RegularETH                      = 'c';
+        public static final char AutomaticExecution              = 'd';
+        public static final char AutomaticExecutionETH           = 'e';
+        public static final char FastMarketETH                   = 'f';
+        public static final char InactiveETH                     = 'g';
+        public static final char Rotation                        = 'h';
+        public static final char RotationETH                     = 'i';
+        public static final char Halt                            = 'j';
+        public static final char HaltETH                         = 'k';
+        public static final char DueToNewsDissemination          = 'l';
+        public static final char DueToNewsPending                = 'm';
+        public static final char TradingResume                   = 'n';
+        public static final char OutOfSequence                   = 'o';
+        public static final char BidSpecialist                   = 'p';
+        public static final char OfferSpecialist                 = 'q';
+        public static final char BidOfferSpecialist              = 'r';
+        public static final char EndOfDaySAM                     = 's';
+        public static final char ForbiddenSAM                    = 't';
+        public static final char FrozenSAM                       = 'u';
+        public static final char PreOpeningSAM                   = 'v';
+        public static final char OpeningSAM                      = 'w';
+        public static final char OpenSAM                         = 'x';
+        public static final char SurveillanceSAM                 = 'y';
+        public static final char SuspendedSAM                    = 'z';
+        public static final char ReservedSAM                     = '0';
+        public static final char NoActiveSAM                     = '1';
+        public static final char Restricted                      = '2';
+        public static final char RestOfBookVWAP                  = '3';
+        public static final char BetterPricesInConditionalOrders = '4';
+        public static final char MedianPrice                     = '5';
+        public static final char FullCurve                       = '6';
+        public static final char FlatCurve                       = '7';
 
         private QuoteConditionValues() {
         }
@@ -1695,12 +1695,12 @@ public class FIX50SP2Enumerations {
      */
     public static class TradingSessionIDValues {
 
-        public static final String Day        = "1";
-        public static final String HalfDay    = "2";
-        public static final String Morning    = "3";
-        public static final String Afternoon  = "4";
-        public static final String Evening    = "5";
-        public static final String AfterHours = "6";
+        public static final char Day        = '1';
+        public static final char HalfDay    = '2';
+        public static final char Morning    = '3';
+        public static final char Afternoon  = '4';
+        public static final char Evening    = '5';
+        public static final char AfterHours = '6';
 
         private TradingSessionIDValues() {
         }
@@ -3038,13 +3038,13 @@ public class FIX50SP2Enumerations {
      */
     public static class TradingSessionSubIDValues {
 
-        public static final String PreTrading              = "1";
-        public static final String OpeningOrOpeningAuction = "2";
-        public static final String Continuous              = "3";
-        public static final String ClosingOrClosingAuction = "4";
-        public static final String PostTrading             = "5";
-        public static final String IntradayAuction         = "6";
-        public static final String Quiescent               = "7";
+        public static final char PreTrading              = '1';
+        public static final char OpeningOrOpeningAuction = '2';
+        public static final char Continuous              = '3';
+        public static final char ClosingOrClosingAuction = '4';
+        public static final char PostTrading             = '5';
+        public static final char IntradayAuction         = '6';
+        public static final char Quiescent               = '7';
 
         private TradingSessionSubIDValues() {
         }
@@ -3081,20 +3081,20 @@ public class FIX50SP2Enumerations {
      */
     public static class ClearingFeeIndicatorValues {
 
-        public static final String FirstYearDelegate             = "1";
-        public static final String SecondYearDelegate            = "2";
-        public static final String ThirdYearDelegate             = "3";
-        public static final String FourthYearDelegate            = "4";
-        public static final String FifthYearDelegate             = "5";
-        public static final String SixthYearDelegate             = "9";
-        public static final String CBOEMember                    = "B";
-        public static final String NonMemberAndCustomer          = "C";
-        public static final String EquityMemberAndClearingMember = "E";
-        public static final String FullAndAssociateMember        = "F";
-        public static final String Firms106HAnd106J              = "H";
-        public static final String GIM                           = "I";
-        public static final String Lessee106FEmployees           = "L";
-        public static final String AllOtherOwnershipTypes        = "M";
+        public static final char FirstYearDelegate             = '1';
+        public static final char SecondYearDelegate            = '2';
+        public static final char ThirdYearDelegate             = '3';
+        public static final char FourthYearDelegate            = '4';
+        public static final char FifthYearDelegate             = '5';
+        public static final char SixthYearDelegate             = '9';
+        public static final char CBOEMember                    = 'B';
+        public static final char NonMemberAndCustomer          = 'C';
+        public static final char EquityMemberAndClearingMember = 'E';
+        public static final char FullAndAssociateMember        = 'F';
+        public static final char Firms106HAnd106J              = 'H';
+        public static final char GIM                           = 'I';
+        public static final char Lessee106FEmployees           = 'L';
+        public static final char AllOtherOwnershipTypes        = 'M';
 
         private ClearingFeeIndicatorValues() {
         }
@@ -4674,8 +4674,8 @@ public class FIX50SP2Enumerations {
      */
     public static class SecurityStatusValues {
 
-        public static final String Active   = "1";
-        public static final String Inactive = "2";
+        public static final char Active   = '1';
+        public static final char Inactive = '2';
 
         private SecurityStatusValues() {
         }
@@ -5285,16 +5285,16 @@ public class FIX50SP2Enumerations {
      */
     public static class ApplVerIDValues {
 
-        public static final String FIX27    = "0";
-        public static final String FIX30    = "1";
-        public static final String FIX40    = "2";
-        public static final String FIX41    = "3";
-        public static final String FIX42    = "4";
-        public static final String FIX43    = "5";
-        public static final String FIX44    = "6";
-        public static final String FIX50    = "7";
-        public static final String FIX50SP1 = "8";
-        public static final String FIX50SP2 = "9";
+        public static final char FIX27    = '0';
+        public static final char FIX30    = '1';
+        public static final char FIX40    = '2';
+        public static final char FIX41    = '3';
+        public static final char FIX42    = '4';
+        public static final char FIX43    = '5';
+        public static final char FIX44    = '6';
+        public static final char FIX50    = '7';
+        public static final char FIX50SP1 = '8';
+        public static final char FIX50SP2 = '9';
 
         private ApplVerIDValues() {
         }

--- a/libraries/fixt11/src/main/java/com/paritytrading/philadelphia/fixt11/FIXT11Enumerations.java
+++ b/libraries/fixt11/src/main/java/com/paritytrading/philadelphia/fixt11/FIXT11Enumerations.java
@@ -59,15 +59,15 @@ public class FIXT11Enumerations {
      */
     public static class ApplVerIDValues {
 
-        public static final String FIX27    = "0";
-        public static final String FIX30    = "1";
-        public static final String FIX40    = "2";
-        public static final String FIX41    = "3";
-        public static final String FIX42    = "4";
-        public static final String FIX43    = "5";
-        public static final String FIX44    = "6";
-        public static final String FIX50    = "7";
-        public static final String FIX50SP1 = "8";
+        public static final char FIX27    = '0';
+        public static final char FIX30    = '1';
+        public static final char FIX40    = '2';
+        public static final char FIX41    = '3';
+        public static final char FIX42    = '4';
+        public static final char FIX43    = '5';
+        public static final char FIX44    = '6';
+        public static final char FIX50    = '7';
+        public static final char FIX50SP1 = '8';
 
         private ApplVerIDValues() {
         }


### PR DESCRIPTION
When reading field values from the FIX Repository, change the type from `String` to `char` if all field values have the length of one character. Working with primitive `char` values is more efficient than working with `String` objects in Java.

**Note.** This is a breaking change and scheduled for Philadelphia 2.0.0.