### PR TITLE
philadelphia-core: Clean up public interface

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXCheckSums.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXCheckSums.java
@@ -1,26 +1,9 @@
 package com.paritytrading.philadelphia;
 
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
-/**
- * Utilities for working with checksums.
- */
-public class FIXCheckSums {
+class FIXCheckSums {
 
-    private FIXCheckSums() {
-    }
-
-    /**
-     * Return the sum of bytes in a buffer.
-     *
-     * @param buffer a buffer
-     * @param offset the offset
-     * @param length the length
-     * @return the sum of bytes in the buffer
-     * @throws BufferUnderflowException if the length from the offset exceeds
-     *   the limit of the buffer
-     */
     public static long sum(ByteBuffer buffer, int offset, int length) {
         long sum = 0;
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTags.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTags.java
@@ -2,14 +2,9 @@ package com.paritytrading.philadelphia;
 
 import static com.paritytrading.philadelphia.FIX.*;
 
-import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
-import java.nio.ReadOnlyBufferException;
 
-/**
- * Utilities for working with tags.
- */
-public class FIXTags {
+class FIXTags {
 
     static final int BeginSeqNo          =   7;
     static final int BeginString         =   8;
@@ -33,16 +28,6 @@ public class FIXTags {
     static final int ResetSeqNumFlag     = 141;
     static final int SessionRejectReason = 373;
 
-    private FIXTags() {
-    }
-
-    /**
-     * Read a tag from a buffer.
-     *
-     * @param buffer a buffer
-     * @return the tag if it was successfully read from the buffer, otherwise
-     *     zero
-     */
     public static int get(ByteBuffer buffer) {
         int tag = 0;
 
@@ -58,16 +43,6 @@ public class FIXTags {
         return 0;
     }
 
-    /**
-     * Write a tag to a buffer.
-     *
-     * @param buffer a buffer
-     * @param tag a tag
-     * @throws IllegalArgumentException if the tag is less than 1 or greater than 99999
-     * @throws BufferOverflowException if there are fewer bytes remaining in
-     *   the buffer than what this tag consists of
-     * @throws ReadOnlyBufferException if the buffer is read-only
-     */
     public static void put(ByteBuffer buffer, int tag) {
         if (tag < 1 || tag > 99999)
             tooLargeTag();

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamps.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamps.java
@@ -2,22 +2,10 @@ package com.paritytrading.philadelphia;
 
 import org.joda.time.ReadableDateTime;
 
-/**
- * Utilities for working with timestamps.
- */
-public class FIXTimestamps {
+class FIXTimestamps {
 
     private static final ThreadLocal<char[]> BUFFER = ThreadLocal.withInitial(() -> new char[21]);
 
-    private FIXTimestamps() {
-    }
-
-    /**
-     * Append a timestamp to a string builder.
-     *
-     * @param t a timestamp
-     * @param s a string builder
-     */
     public static void append(ReadableDateTime t, StringBuilder s) {
         char[] buffer = BUFFER.get();
 


### PR DESCRIPTION
- Remove `FIXCheckSums` from public interface
- Remove `FIXTags` from public interface
- Remove `FIXTimestamps` from public interface

In addition to being used by the library internals, these utility classes are currently part of the public interface. Clean up the public interface and enable further optimizations by making these classes internal.

**Note.** This is a breaking change and scheduled for Philadelphia 2.0.0.