### PR TITLE
Remove Eclipse Collections

### DIFF
--- a/applications/client/pom.xml
+++ b/applications/client/pom.xml
@@ -32,14 +32,6 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jvirtanen.config</groupId>
       <artifactId>config-extras</artifactId>
     </dependency>
@@ -62,15 +54,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>META-INF/ECLIPSE_.RSA</exclude>
-                <exclude>META-INF/ECLIPSE_.SF</exclude>
-              </excludes>
-            </filter>
-          </filters>
           <outputFile>philadelphia-client.jar</outputFile>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
@@ -61,7 +61,7 @@ public class TerminalClient implements Closeable {
 
     public void run(List<String> lines) throws IOException {
         LineReader reader = LineReaderBuilder.builder()
-            .completer(new StringsCompleter(Commands.names().castToList()))
+            .completer(new StringsCompleter(Commands.names()))
             .build();
 
         if (lines.isEmpty())

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/Commands.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/Commands.java
@@ -1,32 +1,34 @@
 package com.paritytrading.philadelphia.client.command;
 
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.factory.Lists;
+import java.util.stream.Stream;
 
 public class Commands {
 
-    private static final ImmutableList<Command> COMMANDS = Lists.immutable.of(
-            new SendCommand(),
-            new MessagesCommand(),
-            new HelpCommand(),
-            new ExitCommand(),
-            new SleepCommand(),
-            new WaitCommand()
-        );
+    private static final Command[] COMMANDS = new Command[] {
+        new SendCommand(),
+        new MessagesCommand(),
+        new HelpCommand(),
+        new ExitCommand(),
+        new SleepCommand(),
+        new WaitCommand(),
+    };
 
     private Commands() {
     }
 
-    public static ImmutableList<Command> all() {
+    public static Command[] all() {
         return COMMANDS;
     }
 
     public static Command find(final String name) {
-        return COMMANDS.select(c -> c.getName().equals(name)).getFirst();
+        return Stream.of(COMMANDS)
+                .filter(c -> c.getName().equals(name))
+                .findFirst()
+                .orElse(null);
     }
 
-    public static ImmutableList<String> names() {
-        return COMMANDS.collect(Command::getName);
+    public static String[] names() {
+        return Stream.of(COMMANDS).map(Command::getName).toArray(String[]::new);
     }
 
 }

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/HelpCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/HelpCommand.java
@@ -2,6 +2,7 @@ package com.paritytrading.philadelphia.client.command;
 
 import com.paritytrading.philadelphia.client.TerminalClient;
 import java.util.Scanner;
+import java.util.stream.Stream;
 
 class HelpCommand implements Command {
 
@@ -38,7 +39,7 @@ class HelpCommand implements Command {
     }
 
     private int calculateMaxCommandNameLength() {
-        return Commands.names().collectInt(String::length).max();
+        return Stream.of(Commands.names()).mapToInt(String::length).max().orElse(0);
     }
 
     @Override

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/MessagesCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/MessagesCommand.java
@@ -2,8 +2,8 @@ package com.paritytrading.philadelphia.client.command;
 
 import com.paritytrading.philadelphia.client.TerminalClient;
 import com.paritytrading.philadelphia.client.message.Message;
+import java.util.List;
 import java.util.Scanner;
-import org.eclipse.collections.api.list.ImmutableList;
 
 class MessagesCommand implements Command {
 
@@ -12,7 +12,7 @@ class MessagesCommand implements Command {
         if (arguments.hasNext()) {
             int index = arguments.nextInt();
 
-            ImmutableList<Message> messages = client.getMessages().collect();
+            List<Message> messages = client.getMessages().collect();
 
             if (index >= 0 && index < +messages.size())
                 client.printf("%s\n", messages.get(index));

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/WaitCommand.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/command/WaitCommand.java
@@ -3,11 +3,8 @@ package com.paritytrading.philadelphia.client.command;
 import com.paritytrading.philadelphia.client.TerminalClient;
 import com.paritytrading.philadelphia.client.message.Message;
 import com.paritytrading.philadelphia.client.message.Messages;
-
+import java.util.List;
 import java.util.Scanner;
-
-import org.eclipse.collections.api.list.ImmutableList;
-
 
 class WaitCommand implements Command {
     private static final long WAIT_TIME_MILLIS = 50;
@@ -51,11 +48,11 @@ class WaitCommand implements Command {
     }
 
     private String getLastMsgType(Messages messages) {
-        ImmutableList<Message> collect = messages.collect();
+        List<Message> collect = messages.collect();
 
         if (collect.isEmpty())
             return null;
 
-        return collect.getLast().getMsgType();
+        return collect.get(collect.size() - 1).getMsgType();
     }
 }

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/message/Message.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/message/Message.java
@@ -2,18 +2,20 @@ package com.paritytrading.philadelphia.client.message;
 
 import com.paritytrading.philadelphia.FIXMessage;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import org.eclipse.collections.api.set.primitive.ImmutableIntSet;
-import org.eclipse.collections.impl.factory.primitive.IntSets;
+import java.util.Set;
 
 public class Message {
 
-    private static final ImmutableIntSet UNPRINTED_TAGS = IntSets.immutable.with(
-        49, // SenderCompID
-        56, // TargetCompID
-        34, // MsgSeqNum
-        52  // SendingTime
-    );
+    private static final Set<Integer> UNPRINTED_TAGS = new HashSet<>();
+
+    static {
+        UNPRINTED_TAGS.add(49); // SenderCompID
+        UNPRINTED_TAGS.add(56); // TargetCompID
+        UNPRINTED_TAGS.add(34); // MsgSeqNum
+        UNPRINTED_TAGS.add(52); // SendingTime
+    }
 
     private static final int MsgType = 35;
 

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/message/Messages.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/message/Messages.java
@@ -4,19 +4,19 @@ import com.paritytrading.philadelphia.FIXConnection;
 import com.paritytrading.philadelphia.FIXConnectionStatusListener;
 import com.paritytrading.philadelphia.FIXMessage;
 import com.paritytrading.philadelphia.FIXMessageListener;
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.factory.Lists;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Messages implements FIXMessageListener, FIXConnectionStatusListener {
 
-    private volatile ImmutableList<Message> messages;
+    private List<Message> messages;
 
     public Messages() {
-        messages = Lists.immutable.with();
+        messages = new ArrayList<>();
     }
 
-    public ImmutableList<Message> collect() {
-        return messages;
+    public synchronized List<Message> collect() {
+        return new ArrayList<>(messages);
     }
 
     @Override
@@ -56,7 +56,11 @@ public class Messages implements FIXMessageListener, FIXConnectionStatusListener
     }
 
     private void add(FIXMessage message) {
-        messages = messages.newWith(Message.get(message));
+        add(Message.get(message));
+    }
+
+    private synchronized void add(Message message) {
+        messages.add(message);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
   </scm>
 
   <properties>
-    <eclipse.collections.version>9.2.0</eclipse.collections.version>
     <java.version>1.8</java.version>
     <jmh.version>1.21</jmh.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -82,16 +81,6 @@
         <artifactId>junit</artifactId>
         <version>4.12</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.collections</groupId>
-        <artifactId>eclipse-collections-api</artifactId>
-        <version>${eclipse.collections.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.collections</groupId>
-        <artifactId>eclipse-collections</artifactId>
-        <version>${eclipse.collections.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hdrhistogram</groupId>


### PR DESCRIPTION
The usage of Eclipse Collections in Philadelphia precedes Java 8. Replace Eclipse Collections with the `java.util.stream` package.