### PR TITLE
philadelphia-generate: Improve version handling

### DIFF
--- a/applications/generate/pom.xml
+++ b/applications/generate/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.paritytrading.philadelphia</groupId>
+    <artifactId>philadelphia-parent</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>philadelphia-generate</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Philadelphia Code Generator</name>
+
+</project>

--- a/applications/generate/setup.py
+++ b/applications/generate/setup.py
@@ -1,8 +1,17 @@
 from setuptools import setup, find_packages
 
+import xml.etree.ElementTree
+
+
+def find_version():
+    tree = xml.etree.ElementTree.parse('pom.xml')
+    ns = {'POM': 'https://maven.apache.org/POM/4.0.0'}
+    return tree.find('./POM:parent/POM:version', ns).text
+
+
 setup(
     name='philadelphia',
-    version='1.0.0',
+    version=find_version(),
     packages=find_packages(),
     entry_points={
         'console_scripts': [

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
   <modules>
     <module>applications/client</module>
+    <module>applications/generate</module>
     <module>examples/acceptor</module>
     <module>examples/initiator</module>
     <module>libraries/core</module>

--- a/scripts/archive.txt
+++ b/scripts/archive.txt
@@ -13,6 +13,7 @@ applications/generate/philadelphia/java.py
 applications/generate/philadelphia/model.py
 applications/generate/philadelphia/quickfix.py
 applications/generate/philadelphia/repository.py
+applications/generate/pom.xml
 applications/generate/setup.py
 examples/acceptor/README.md
 examples/acceptor/philadelphia-acceptor.jar


### PR DESCRIPTION
Add a Maven module for Philadelphia Code Generator. Make Philadelphia Code Generator's version track Philadelphia's version by reading the value from `pom.xml` in `setup.py`.