### PR TITLE
philadelphia-core: Remove 'FIXValue#asCheckSum'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
@@ -127,7 +127,7 @@ public class FIXMessageParser {
 
                 // Garbled message
                 if (FIXCheckSums.sum(buffer, beginning, position - beginning + length) % 256
-                        != checkSum.asCheckSum())
+                        != checkSum.asInt())
                     continue;
 
                 buffer.position(position);

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -427,16 +427,6 @@ public class FIXValue {
     }
 
     /**
-     * Get the value as a checksum.
-     *
-     * @return the value as a checksum
-     * @throws FIXValueFormatException if the value is not an integer
-     */
-    public long asCheckSum() {
-        return asInt();
-    }
-
-    /**
      * Set the value to a checksum.
      *
      * @param c a checksum

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -351,24 +351,10 @@ public class FIXValueTest {
     }
 
     @Test
-    public void asCheckSum() throws FIXValueOverflowException {
-        get("064\u0001");
-
-        assertEquals(64, value.asCheckSum());
-    }
-
-    @Test
     public void setCheckSum() {
         value.setCheckSum(320);
 
         assertPutEquals("064\u0001");
-    }
-
-    @Test(expected=FIXValueFormatException.class)
-    public void notCheckSum() {
-        value.setString("FOO");
-
-        value.asCheckSum();
     }
 
     @Test(expected=FIXValueOverflowException.class)


### PR DESCRIPTION
It is just an alias for `FIXValue#asInt`.

**Note.** This is a breaking change and scheduled for Philadelphia 2.0.0.
