### PR TITLE
philadelphia-generate: Add comment to output files

### DIFF
--- a/applications/generate/philadelphia/java.py
+++ b/applications/generate/philadelphia/java.py
@@ -3,6 +3,16 @@ import string
 import textwrap
 
 
+COMPILATION_UNIT_COMMENT = '''\
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */\
+'''
+
+
 class CompilationUnit(object):
 
     def __init__(self, package, class_):
@@ -10,7 +20,8 @@ class CompilationUnit(object):
         self.class_ = class_
 
     def __str__(self):
-        return '{}\n\n{}'.format(self.package, self.class_)
+        return '{}\n\n{}\n\n{}'.format(self.package, COMPILATION_UNIT_COMMENT,
+                self.class_)
 
 
 class Package(object):

--- a/libraries/fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42Enumerations.java
+++ b/libraries/fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42Enumerations.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix42;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Enumerations for FIX 4.2.
  */

--- a/libraries/fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42MsgTypes.java
+++ b/libraries/fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42MsgTypes.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix42;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Message types for FIX 4.2.
  */

--- a/libraries/fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42Tags.java
+++ b/libraries/fix42/src/main/java/com/paritytrading/philadelphia/fix42/FIX42Tags.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix42;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Tags for FIX 4.2.
  */

--- a/libraries/fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43Enumerations.java
+++ b/libraries/fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43Enumerations.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix43;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Enumerations for FIX 4.3.
  */

--- a/libraries/fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43MsgTypes.java
+++ b/libraries/fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43MsgTypes.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix43;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Message types for FIX 4.3.
  */

--- a/libraries/fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43Tags.java
+++ b/libraries/fix43/src/main/java/com/paritytrading/philadelphia/fix43/FIX43Tags.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix43;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Tags for FIX 4.3.
  */

--- a/libraries/fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44Enumerations.java
+++ b/libraries/fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44Enumerations.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix44;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Enumerations for FIX 4.4.
  */

--- a/libraries/fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44MsgTypes.java
+++ b/libraries/fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44MsgTypes.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix44;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Message types for FIX 4.4.
  */

--- a/libraries/fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44Tags.java
+++ b/libraries/fix44/src/main/java/com/paritytrading/philadelphia/fix44/FIX44Tags.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix44;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Tags for FIX 4.4.
  */

--- a/libraries/fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50Enumerations.java
+++ b/libraries/fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50Enumerations.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Enumerations for FIX 5.0.
  */

--- a/libraries/fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50MsgTypes.java
+++ b/libraries/fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50MsgTypes.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Message types for FIX 5.0.
  */

--- a/libraries/fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50Tags.java
+++ b/libraries/fix50/src/main/java/com/paritytrading/philadelphia/fix50/FIX50Tags.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Tags for FIX 5.0.
  */

--- a/libraries/fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1Enumerations.java
+++ b/libraries/fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1Enumerations.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50sp1;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Enumerations for FIX 5.0 SP1.
  */

--- a/libraries/fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1MsgTypes.java
+++ b/libraries/fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1MsgTypes.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50sp1;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Message types for FIX 5.0 SP1.
  */

--- a/libraries/fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1Tags.java
+++ b/libraries/fix50sp1/src/main/java/com/paritytrading/philadelphia/fix50sp1/FIX50SP1Tags.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50sp1;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Tags for FIX 5.0 SP1.
  */

--- a/libraries/fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2Enumerations.java
+++ b/libraries/fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2Enumerations.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50sp2;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Enumerations for FIX 5.0 SP2.
  */

--- a/libraries/fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2MsgTypes.java
+++ b/libraries/fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2MsgTypes.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50sp2;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Message types for FIX 5.0 SP2.
  */

--- a/libraries/fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2Tags.java
+++ b/libraries/fix50sp2/src/main/java/com/paritytrading/philadelphia/fix50sp2/FIX50SP2Tags.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fix50sp2;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Tags for FIX 5.0 SP2.
  */

--- a/libraries/fixt11/src/main/java/com/paritytrading/philadelphia/fixt11/FIXT11Enumerations.java
+++ b/libraries/fixt11/src/main/java/com/paritytrading/philadelphia/fixt11/FIXT11Enumerations.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fixt11;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Enumerations for FIXT 1.1.
  */

--- a/libraries/fixt11/src/main/java/com/paritytrading/philadelphia/fixt11/FIXT11MsgTypes.java
+++ b/libraries/fixt11/src/main/java/com/paritytrading/philadelphia/fixt11/FIXT11MsgTypes.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fixt11;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Message types for FIXT 1.1.
  */

--- a/libraries/fixt11/src/main/java/com/paritytrading/philadelphia/fixt11/FIXT11Tags.java
+++ b/libraries/fixt11/src/main/java/com/paritytrading/philadelphia/fixt11/FIXT11Tags.java
@@ -1,5 +1,12 @@
 package com.paritytrading.philadelphia.fixt11;
 
+/*
+ * This file has been automatically generated using Philadelphia Code
+ * Generator. For more information on Philadelphia Code Generator, see:
+ *
+ *   https://github.com/paritytrading/philadelphia
+ */
+
 /**
  * Tags for FIXT 1.1.
  */


### PR DESCRIPTION
Add a comment to the output files of Philadelphia Code Generator indicating that they have been automatically generated.