### PR TITLE
philadelphia-core: Fix 'FIXValue#set'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -79,10 +79,10 @@ public class FIXValue {
      * @param value a value container
      */
     public void set(FIXValue value) {
-        offset = 0;
+        offset = value.offset;
         length = value.length;
 
-        System.arraycopy(value.bytes, 0, bytes, 0, length + 1);
+        System.arraycopy(value.bytes, offset, bytes, offset, length + 1);
     }
 
     /**

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -41,7 +41,7 @@ public class FIXValueTest {
     }
 
     @Test
-    public void set() {
+    public void setWithoutOffset() {
         FIXValue anotherValue = new FIXValue(32);
 
         anotherValue.setString("FOO");
@@ -49,6 +49,17 @@ public class FIXValueTest {
         value.set(anotherValue);
 
         assertPutEquals("FOO\u0001");
+    }
+
+    @Test
+    public void setWithOffset() {
+        FIXValue anotherValue = new FIXValue(32);
+
+        anotherValue.setInt(123);
+
+        value.set(anotherValue);
+
+        assertPutEquals("123\u0001");
     }
 
     @Test


### PR DESCRIPTION
The `FIXValue#set` method fails if the specified value container contains a value at a non-zero offset. Fix this.