### PR TITLE
philadelphia-core: Replace modulo with power of two bitmask

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
@@ -126,7 +126,7 @@ public class FIXMessageParser {
                     continue;
 
                 // Garbled message
-                if (FIXCheckSums.sum(buffer, beginning, position - beginning + length) % 256
+                if ((FIXCheckSums.sum(buffer, beginning, position - beginning + length) & 0xff)
                         != checkSum.asCheckSum())
                     continue;
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -442,7 +442,7 @@ public class FIXValue {
      * @param c a checksum
      */
     public void setCheckSum(long c) {
-        setDigits(c % 256, 0, 3);
+        setDigits(c & 0xff, 0, 3);
         bytes[3] = SOH;
 
         offset = 0;


### PR DESCRIPTION
Minor performance improvement for checksum calculations by replacing power of two modulo operations with bitwise AND.

JIT might or might not do this optimisation eventually but order entry is frequently not entirely hot so this should be a clear and simple improvement.