### PR TITLE
philadelphia-core: Improve 'FIXMessageParser'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
@@ -124,29 +124,8 @@ public class FIXMessageParser {
 
             position = buffer.position();
 
-            if (checkSumEnabled) {
-                buffer.position(position + length);
-
-                // Garbled message
-                tag = FIXTags.get(buffer);
-                if (tag == 0)
-                    continue;
-
-                // Garbled message
-                if (!checkSum.get(buffer))
-                    continue;
-
-                // Garbled message
-                if (tag != CheckSum)
-                    continue;
-
-                // Garbled message
-                if ((FIXCheckSums.sum(buffer, beginning, position - beginning + length) & 0xff)
-                        != checkSum.asInt())
-                    continue;
-
-                buffer.position(position);
-            }
+            if (checkSumEnabled && !acceptCheckSum(buffer, beginning, position, length))
+                continue;
 
             int limit = buffer.limit();
 
@@ -165,6 +144,32 @@ public class FIXMessageParser {
 
             return true;
         }
+    }
+
+    private boolean acceptCheckSum(ByteBuffer buffer, int beginning, int position, int length) throws IOException {
+        buffer.position(position + length);
+
+        // Garbled message
+        int tag = FIXTags.get(buffer);
+        if (tag == 0)
+            return false;
+
+        // Garbled message
+        if (!checkSum.get(buffer))
+            return false;
+
+        // Garbled message
+        if (tag != CheckSum)
+            return false;
+
+        // Garbled message
+        if ((FIXCheckSums.sum(buffer, beginning, position - beginning + length) & 0xff)
+                != checkSum.asInt())
+            return false;
+
+        buffer.position(position);
+
+        return true;
     }
 
 }

--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXMessageParserBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXMessageParserBenchmark.java
@@ -29,9 +29,13 @@ public class FIXMessageParserBenchmark extends FIXBenchmark {
             "56=acceptor\u000134=2\u000111=123\u000121=1\u000155=FOO\u000154=1\u000140=2\u0001" +
             "44=150.25\u000110=075\u0001";
 
+    private static final FIXConfig CHECK_SUM_ENABLED  = new FIXConfig.Builder().build();
+    private static final FIXConfig CHECK_SUM_DISABLED = new FIXConfig.Builder().setCheckSumEnabled(false).build();
+
     private ByteBuffer buffer;
 
-    private FIXMessageParser parser;
+    private FIXMessageParser checkSumEnabled;
+    private FIXMessageParser checkSumDisabled;
 
     @Setup(Level.Iteration)
     public void prepare() {
@@ -40,9 +44,8 @@ public class FIXMessageParserBenchmark extends FIXBenchmark {
         buffer.put(MESSAGE.getBytes(US_ASCII));
         buffer.flip();
 
-        FIXConfig config = new FIXConfig.Builder().build();
-
-        parser = new FIXMessageParser(config, listener -> {});
+        checkSumEnabled  = new FIXMessageParser(CHECK_SUM_ENABLED,  listener -> {});
+        checkSumDisabled = new FIXMessageParser(CHECK_SUM_DISABLED, listener -> {});
     }
 
     @Benchmark
@@ -50,8 +53,17 @@ public class FIXMessageParserBenchmark extends FIXBenchmark {
     }
 
     @Benchmark
-    public boolean parse() throws IOException {
-        boolean result = parser.parse(buffer);
+    public boolean checkSumEnabled() throws IOException {
+        boolean result = checkSumEnabled.parse(buffer);
+
+        buffer.flip();
+
+        return result;
+    }
+
+    @Benchmark
+    public boolean checkSumDisabled() throws IOException {
+        boolean result = checkSumDisabled.parse(buffer);
 
         buffer.flip();
 

--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXMessageParserBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXMessageParserBenchmark.java
@@ -15,9 +15,7 @@
  */
 package com.paritytrading.philadelphia;
 
-import static com.paritytrading.philadelphia.fix42.FIX42Enumerations.*;
-import static com.paritytrading.philadelphia.fix42.FIX42MsgTypes.*;
-import static com.paritytrading.philadelphia.fix42.FIX42Tags.*;
+import static java.nio.charset.StandardCharsets.*;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -27,41 +25,24 @@ import org.openjdk.jmh.annotations.Setup;
 
 public class FIXMessageParserBenchmark extends FIXBenchmark {
 
+    private static final String MESSAGE = "8=FIX.4.2\u00019=74\u000135=D\u000149=initiator\u0001" +
+            "56=acceptor\u000134=2\u000111=123\u000121=1\u000155=FOO\u000154=1\u000140=2\u0001" +
+            "44=150.25\u000110=075\u0001";
+
     private ByteBuffer buffer;
 
-    private FIXMessageParser messageParser;
+    private FIXMessageParser parser;
 
     @Setup(Level.Iteration)
     public void prepare() {
-        FIXMessage message = new FIXMessage(64, 64);
-
-        format(message);
-
         buffer = ByteBuffer.allocateDirect(1024);
 
-        message.put(buffer);
-
+        buffer.put(MESSAGE.getBytes(US_ASCII));
         buffer.flip();
 
-        FIXConfig fixConfig = new FIXConfig.Builder().build();
+        FIXConfig config = new FIXConfig.Builder().build();
 
-        messageParser = new FIXMessageParser(fixConfig, listener -> {});
-    }
-
-    private void format(FIXMessage message) {
-        message.addField(BeginString).setString("FIX.4.2");
-        message.addField(BodyLength).setInt(74);
-        message.addField(MsgType).setChar(OrderSingle);
-        message.addField(SenderCompID).setString("initiator");
-        message.addField(TargetCompID).setString("acceptor");
-        message.addField(MsgSeqNum).setInt(2);
-        message.addField(ClOrdID).setString("123");
-        message.addField(HandlInst).setChar(HandlInstValues.AutomatedExecutionNoIntervention);
-        message.addField(Symbol).setString("FOO");
-        message.addField(Side).setChar(SideValues.Buy);
-        message.addField(OrdType).setChar(OrdTypeValues.Limit);
-        message.addField(Price).setFloat(150.25, 2);
-        message.addField(CheckSum).setCheckSum(75);
+        parser = new FIXMessageParser(config, listener -> {});
     }
 
     @Benchmark
@@ -70,10 +51,11 @@ public class FIXMessageParserBenchmark extends FIXBenchmark {
 
     @Benchmark
     public boolean parse() throws IOException {
-        boolean success = messageParser.parse(buffer);
+        boolean result = parser.parse(buffer);
 
         buffer.flip();
 
-        return success;
+        return result;
     }
+
 }


### PR DESCRIPTION
Having the incoming CheckSum(10) check in a separate method makes message parsing 9.6% faster in the performance test when the incoming CheckSum(10) check is disabled and 3.7% faster when it is enabled.