### PR TITLE
philadelphia-core: Improve MsgType(35) handling

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -532,7 +532,7 @@ public class FIXConnection implements Closeable {
                 return;
             }
 
-            if (msgType.length() == 1 && msgType.byteAt(0) == SequenceReset) {
+            if (msgType.byteAt(0) == SequenceReset && msgType.length() == 1) {
                 if (handleSequenceReset(message))
                     return;
             }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -561,9 +561,6 @@ public class FIXConnection implements Closeable {
             case Reject:
                 handleReject(message);
                 break;
-            case SequenceReset:
-                handleSequenceReset(message);
-                break;
             case Logout:
                 handleLogout(message);
                 break;


### PR DESCRIPTION
When checking for SequenceReset(4), check the first byte of the MsgType(35) value before checking its length. This avoids one conditional check for most messages.

Note that the length of the MsgType(35) value could in principle be zero. In that case, "the first byte of the value" is actually the SOH character.