### PR TITLE
philadelphia-core: Fix 'FIXValue#asDate'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -325,7 +325,7 @@ public class FIXValue {
         int monthOfYear = getDigits(2, offset + 4);
         int dayOfMonth  = getDigits(2, offset + 6);
 
-        d.setDateTime(year, monthOfYear, dayOfMonth, 0, 0, 0, 0);
+        d.setDate(year, monthOfYear, dayOfMonth);
     }
 
     /**

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -18,7 +18,6 @@ package com.paritytrading.philadelphia;
 import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
-import org.joda.time.LocalTime;
 import org.joda.time.MutableDateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -299,22 +298,22 @@ public class FIXValueTest {
     public void asTimeOnlyWithMillis() throws FIXValueOverflowException {
         get("09:30:05.250");
 
-        MutableDateTime t = new MutableDateTime();
+        MutableDateTime t = new MutableDateTime(2015, 9, 24, 22, 45, 10, 750);
 
         value.asTimeOnly(t);
 
-        assertEquals(new LocalTime(9, 30, 5, 250), new LocalTime(t));
+        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), t);
     }
 
     @Test
     public void asTimeOnlyWithoutMillis() throws FIXValueOverflowException {
         get("09:30:05");
 
-        MutableDateTime t = new MutableDateTime();
+        MutableDateTime t = new MutableDateTime(2015, 9, 24, 22, 45, 10, 750);
 
         value.asTimeOnly(t);
 
-        assertEquals(new LocalTime(9, 30, 5, 0), new LocalTime(t));
+        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 0), t);
     }
 
     @Test

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -281,11 +281,11 @@ public class FIXValueTest {
     public void asDate() throws FIXValueOverflowException {
         get("20150924");
 
-        MutableDateTime d = new MutableDateTime();
+        MutableDateTime d = new MutableDateTime(1970, 1, 1, 9, 30, 5, 250);
 
         value.asDate(d);
 
-        assertEquals(new MutableDateTime(2015, 9, 24, 0, 0, 0, 0), d);
+        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), d);
     }
 
     @Test


### PR DESCRIPTION
When reading a date value, only set the date fields, not the time fields. `FIXValue#asTimeOnly` already works in this manner.

This makes it possible to combine the outputs of `FIXValue#asDate` and `FIXValue#asTimeOnly`. These data types are used in fields such as MDEntryDate(272) and MDEntryTime(273).