### PR TITLE
philadelphia-core: Optimize Joda-Time operations

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -321,11 +321,9 @@ public class FIXValue {
         if (length != 8)
             notDate();
 
-        int year        = getDigits(4, offset + 0);
-        int monthOfYear = getDigits(2, offset + 4);
-        int dayOfMonth  = getDigits(2, offset + 6);
-
-        d.setDate(year, monthOfYear, dayOfMonth);
+        d.setYear(getDigits(4, offset + 0));
+        d.setMonthOfYear(getDigits(2, offset + 4));
+        d.setDayOfMonth(getDigits(2, offset + 6));
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -395,16 +395,13 @@ public class FIXValue {
         if (length != 17 && length != 21)
             notTimestamp();
 
-        int year           = getDigits(4, offset + 0);
-        int monthOfYear    = getDigits(2, offset + 4);
-        int dayOfMonth     = getDigits(2, offset + 6);
-        int hourOfDay      = getDigits(2, offset + 9);
-        int minuteOfHour   = getDigits(2, offset + 12);
-        int secondOfMinute = getDigits(2, offset + 15);
-        int millisOfSecond = length == 21 ? getDigits(3, offset + 18) : 0;
-
-        t.setDateTime(year, monthOfYear, dayOfMonth, hourOfDay, minuteOfHour,
-                secondOfMinute, millisOfSecond);
+        t.setYear(getDigits(4, offset + 0));
+        t.setMonthOfYear(getDigits(2, offset + 4));
+        t.setDayOfMonth(getDigits(2, offset + 6));
+        t.setHourOfDay(getDigits(2, offset + 9));
+        t.setMinuteOfHour(getDigits(2, offset + 12));
+        t.setSecondOfMinute(getDigits(2, offset + 15));
+        t.setMillisOfSecond(length == 21 ? getDigits(3, offset + 18) : 0);
     }
 
     /**


### PR DESCRIPTION
In `FIXValue#asDate`, setting the date components one by one surprisingly takes only roughly 45% of the time it takes to set them all at once. In `FIXValue#asTimestamp`, too, setting the date and time components one by one gives a modest performance improvement as opposed to setting them all at once.