### PR TITLE
philadelphia-core: Mark 'FIXValue#asCheckSum' as deprecated

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
@@ -142,7 +142,7 @@ public class FIXMessageParser {
 
                 // Garbled message
                 if ((FIXCheckSums.sum(buffer, beginning, position - beginning + length) & 0xff)
-                        != checkSum.asCheckSum())
+                        != checkSum.asInt())
                     continue;
 
                 buffer.position(position);

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -503,7 +503,9 @@ public class FIXValue {
      *
      * @return the value as a checksum
      * @throws FIXValueFormatException if the value is not an integer
+     * @deprecated Use {@link #asInt()} instead.
      */
+    @Deprecated
     public long asCheckSum() {
         return asInt();
     }


### PR DESCRIPTION
It will be removed in Philadelphia 2.0.0.