### PR TITLE
philadelphia-core: Clean up test classes

### DIFF
--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/ByteBuffers.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/ByteBuffers.java
@@ -21,11 +21,11 @@ import java.nio.ByteBuffer;
 
 class ByteBuffers {
 
-    public static String getString(ByteBuffer buffer) {
+    static String getString(ByteBuffer buffer) {
         return getString(buffer, buffer.remaining());
     }
 
-    public static String getString(ByteBuffer buffer, int length) {
+    static String getString(ByteBuffer buffer, int length) {
         byte[] bytes = new byte[length];
 
         buffer.get(bytes);
@@ -33,7 +33,7 @@ class ByteBuffers {
         return new String(bytes, US_ASCII);
     }
 
-    public static ByteBuffer wrap(String s) {
+    static ByteBuffer wrap(String s) {
         return ByteBuffer.wrap(s.getBytes(US_ASCII));
     }
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
@@ -22,11 +22,11 @@ class FIXConnectionStatus implements FIXConnectionStatusListener {
 
     private List<Event> events;
 
-    public FIXConnectionStatus() {
+    FIXConnectionStatus() {
         this.events = new ArrayList<>();
     }
 
-    public List<Event> collect() {
+    List<Event> collect() {
         return events;
     }
 
@@ -65,40 +65,40 @@ class FIXConnectionStatus implements FIXConnectionStatusListener {
         events.add(new Logout());
     }
 
-    public interface Event {
+    interface Event {
     }
 
-    public static class Close extends Value implements Event {
-        public final String message;
+    static class Close extends Value implements Event {
+        final String message;
 
-        public Close(String message) {
+        Close(String message) {
             this.message = message;
         }
     }
 
-    public static class SequenceReset extends Value implements Event {
+    static class SequenceReset extends Value implements Event {
     }
 
-    public static class TooLowMsgSeqNum extends Value implements Event {
-        public final long receivedMsgSeqNum;
-        public final long expectedMsgSeqNum;
+    static class TooLowMsgSeqNum extends Value implements Event {
+        final long receivedMsgSeqNum;
+        final long expectedMsgSeqNum;
 
-        public TooLowMsgSeqNum(long receivedMsgSeqNum, long expectedMsgSeqNum) {
+        TooLowMsgSeqNum(long receivedMsgSeqNum, long expectedMsgSeqNum) {
             this.receivedMsgSeqNum = receivedMsgSeqNum;
             this.expectedMsgSeqNum = expectedMsgSeqNum;
         }
     }
 
-    public static class HeartbeatTimeout extends Value implements Event {
+    static class HeartbeatTimeout extends Value implements Event {
     }
 
-    public static class Reject extends Value implements Event {
+    static class Reject extends Value implements Event {
     }
 
-    public static class Logon extends Value implements Event {
+    static class Logon extends Value implements Event {
     }
 
-    public static class Logout extends Value implements Event {
+    static class Logout extends Value implements Event {
     }
 
 }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXMessages.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXMessages.java
@@ -25,13 +25,13 @@ class FIXMessages implements FIXMessageListener {
 
     private ByteBuffer buffer;
 
-    public FIXMessages() {
+    FIXMessages() {
         this.messages = new ArrayList<>();
 
         this.buffer = ByteBuffer.allocateDirect(1024);
     }
 
-    public List<String> collect() {
+    List<String> collect() {
         return messages;
     }
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FixedClock.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FixedClock.java
@@ -24,7 +24,7 @@ class FixedClock implements Clock {
         return currentTimeMillis;
     }
 
-    public void setCurrentTimeMillis(long currentTimeMillis) {
+    void setCurrentTimeMillis(long currentTimeMillis) {
         this.currentTimeMillis = currentTimeMillis;
     }
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/Strings.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/Strings.java
@@ -17,7 +17,7 @@ package com.paritytrading.philadelphia;
 
 class Strings {
 
-    public static String repeat(char c, int num) {
+    static String repeat(char c, int num) {
         StringBuilder builder = new StringBuilder(num);
 
         for (int i = 0; i < num; i++)

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/TestConnection.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/TestConnection.java
@@ -33,7 +33,7 @@ class TestConnection implements Closeable {
 
     private TestMessageParser parser;
 
-    public TestConnection(SocketChannel channel, TestMessageListener listener) {
+    TestConnection(SocketChannel channel, TestMessageListener listener) {
         this.channel = channel;
 
         this.parser = new TestMessageParser(listener);
@@ -42,7 +42,7 @@ class TestConnection implements Closeable {
         this.txBuffer = ByteBuffer.allocateDirect(2048);
     }
 
-    public int receive() throws IOException {
+    int receive() throws IOException {
         int bytes = channel.read(rxBuffer);
 
         if (bytes <= 0)
@@ -57,11 +57,11 @@ class TestConnection implements Closeable {
         return bytes;
     }
 
-    public void send(String message) throws IOException {
+    void send(String message) throws IOException {
         send(asList(message));
     }
 
-    public void send(List<String> messages) throws IOException {
+    void send(List<String> messages) throws IOException {
         txBuffer.clear();
 
         for (String message : messages)

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/TestMessageParser.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/TestMessageParser.java
@@ -28,7 +28,7 @@ class TestMessageParser {
 
     private FIXValue value;
 
-    public TestMessageParser(TestMessageListener listener) {
+    TestMessageParser(TestMessageListener listener) {
         this.listener = listener;
 
         this.message = new StringBuilder();
@@ -36,7 +36,7 @@ class TestMessageParser {
         this.value = new FIXValue(32);
     }
 
-    public boolean parse(ByteBuffer buffer) throws IOException {
+    boolean parse(ByteBuffer buffer) throws IOException {
         buffer.mark();
 
         message.setLength(0);

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/TestMessages.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/TestMessages.java
@@ -22,11 +22,11 @@ class TestMessages implements TestMessageListener {
 
     private List<String> messages;
 
-    public TestMessages() {
+    TestMessages() {
         this.messages = new ArrayList<>();
     }
 
-    public List<String> collect() {
+    List<String> collect() {
         return messages;
     }
 


### PR DESCRIPTION
Remove superfluous `public` modifiers.