### PR TITLE
Clean up array initializers

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
@@ -46,7 +46,7 @@ import org.jvirtanen.config.Configs;
 
 class TerminalClient implements Closeable {
 
-    static final Command[] COMMANDS = new Command[] {
+    static final Command[] COMMANDS = {
         new SendCommand(),
         new MessagesCommand(),
         new HelpCommand(),

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIX.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIX.java
@@ -25,11 +25,11 @@ class FIX {
 
     static final byte NO = 'N';
 
-    static final byte[] BEGIN_STRING = new byte[] { '8', '=' };
+    static final byte[] BEGIN_STRING = { '8', '=' };
 
-    static final byte[] BODY_LENGTH = new byte[] { '9', '=' };
+    static final byte[] BODY_LENGTH = { '9', '=' };
 
-    static final byte[] CHECK_SUM = new byte[] { '1', '0', '=' };
+    static final byte[] CHECK_SUM = { '1', '0', '=' };
 
     static final int BEGIN_STRING_FIELD_CAPACITY = 16;
 

--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXTagsBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXTagsBenchmark.java
@@ -26,7 +26,7 @@ public class FIXTagsBenchmark extends FIXBenchmark {
 
     @Setup(Level.Iteration)
     public void prepare() {
-        byte[] bytes = new byte[] { '1', '2', '3', '=' };
+        byte[] bytes = { '1', '2', '3', '=' };
 
         buffer = ByteBuffer.allocateDirect(bytes.length);
 


### PR DESCRIPTION
When possible, use an array initializer instead of a full-blown array creation expression.