### PR TITLE
philadelphia-core: Remove transitive Joda-Time dependency

### DIFF
--- a/applications/client/pom.xml
+++ b/applications/client/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>config</artifactId>
     </dependency>
     <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jline-reader</artifactId>
     </dependency>

--- a/examples/acceptor/pom.xml
+++ b/examples/acceptor/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>philadelphia-fix42</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/examples/initiator/pom.xml
+++ b/examples/initiator/pom.xml
@@ -40,6 +40,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
     </dependency>

--- a/libraries/core/README.md
+++ b/libraries/core/README.md
@@ -6,7 +6,18 @@ Philadelphia Core implements the Financial Information Exchange (FIX) protocol.
 
 Philadelphia Core depends on the following libraries:
 
-- Joda-Time 2.10.5
+- Joda-Time 2.x
+
+If you do not already use Joda-Time 2.x in your application, add a Maven
+dependency to it. For example:
+
+```xml
+<dependency>
+  <groupId>joda-time</groupId>
+  <artifactId>joda-time</artifactId>
+  <version>2.10.5</version>
+</dependency>
+```
 
 ## Download
 

--- a/libraries/core/pom.xml
+++ b/libraries/core/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Currently, Philadelphia Core depends on Joda-Time 2.10.5. This means that any application that has a dependency on Philadelphia Core also has a transitive dependency on Joda-Time 2.10.5.

Replace the transitive Joda-Time 2.10.5 dependency with a Joda-Time 2.x dependency. This makes it possible for applications to manage their Joda-Time 2.x and Philadelphia Core dependencies independently.

This also means that applications that use Philadelphia Core but do not yet use Joda-Time 2.x need to add a dependency on Joda-Time 2.x as well.