### PR TITLE
philadelphia-core: Fix 'FIXValue#asDate'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -376,16 +376,26 @@ public class FIXValue {
     /**
      * Get the value as a date.
      *
+     * <p><strong>Note.</strong> This method sets both date and time fields.
+     * When combining this method and {@link #asTimeOnly(MutableDateTime)},
+     * this method should be invoked first.</p>
+     *
      * @param x a date
      * @throws FIXValueFormatException if the value is not a date
+     * @see #asTimeOnly(MutableDateTime)
      */
     public void asDate(MutableDateTime x) {
         if (length != 8)
             notDate();
 
-        x.setYear(getDigits(4, offset + 0));
-        x.setMonthOfYear(getDigits(2, offset + 4));
-        x.setDayOfMonth(getDigits(2, offset + 6));
+        int year        = getDigits(4, offset + 0);
+        int monthOfYear = getDigits(2, offset + 4);
+        int dayOfMonth  = getDigits(2, offset + 6);
+
+        // Note: 'setDateTime()' takes roughly 55% of the time 'setDate()'
+        // takes. Using individual methods, such as 'setYear()', is faster
+        // than using 'setDate()' but still slower than 'setDateTime()'.
+        x.setDateTime(year, monthOfYear, dayOfMonth, 0, 0, 0, 0);
     }
 
     /**
@@ -408,6 +418,7 @@ public class FIXValue {
      *
      * @param x a time only
      * @throws FIXValueFormatException if the value is not a time only
+     * @see #asDate(MutableDateTime)
      */
     public void asTimeOnly(MutableDateTime x) {
         if (length != 8 && length != 12)

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -284,7 +284,7 @@ public class FIXValueTest {
 
         value.asDate(d);
 
-        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), d);
+        assertEquals(new MutableDateTime(2015, 9, 24, 0, 0, 0, 0), d);
     }
 
     @Test


### PR DESCRIPTION
This fixes a performance regression in the method by reverting the changes done since the 1.1.1 release.

In the commit 1f0a1888f972923ae32b6c3f86e7f8e78d430b8b the method was changed so that it only sets the date fields and not the time fields. This made the method 82% slower.

In the commit fee88745a7d228873b15fbde78afd24cd0607367 the method was changed so that it sets the date fields one by one rather than all at once. This made the method faster again, but it was still 62% slower than in the 1.1.1 release.