### PR TITLE
philadelphia-core: Fix 'FIXValue#asTimestamp'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -457,13 +457,16 @@ public class FIXValue {
         if (length != 17 && length != 21)
             notTimestamp();
 
-        x.setYear(getDigits(4, offset + 0));
-        x.setMonthOfYear(getDigits(2, offset + 4));
-        x.setDayOfMonth(getDigits(2, offset + 6));
-        x.setHourOfDay(getDigits(2, offset + 9));
-        x.setMinuteOfHour(getDigits(2, offset + 12));
-        x.setSecondOfMinute(getDigits(2, offset + 15));
-        x.setMillisOfSecond(length == 21 ? getDigits(3, offset + 18) : 0);
+        int year           = getDigits(4, offset + 0);
+        int monthOfYear    = getDigits(2, offset + 4);
+        int dayOfMonth     = getDigits(2, offset + 6);
+        int hourOfDay      = getDigits(2, offset + 9);
+        int minuteOfHour   = getDigits(2, offset + 12);
+        int secondOfMinute = getDigits(2, offset + 15);
+        int millisOfSecond = length == 21 ? getDigits(3, offset + 18) : 0;
+
+        x.setDateTime(year, monthOfYear, dayOfMonth, hourOfDay, minuteOfHour,
+                secondOfMinute, millisOfSecond);
     }
 
     /**


### PR DESCRIPTION
This fixes a performance regression in the method by reverting the changes done since the 1.1.1 release.

In the commit 51444a7 the method was changed so that it sets the fields one by one rather than all at once. This made the method 3.8x slower.