### PR TITLE
philadelphia-generate: Skip Maven deployment

### DIFF
--- a/applications/generate/pom.xml
+++ b/applications/generate/pom.xml
@@ -29,4 +29,16 @@
 
   <name>Philadelphia Code Generator</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
As with the other executables, such as Philadelphia Terminal Client, skip the Maven deployment of Philadelphia Code Generator. In practice this means that this POM will no longer be uploaded to the Central Repository as a part of a Philadelphia release.