### PR TITLE
philadelphia-core: Optimize 'FIXValue#setDigits'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -595,8 +595,8 @@ public class FIXValue {
     }
 
     private void setDigits(int value, int offset, int digits) {
-        for (int i = offset + digits - 1; i >= offset; i--) {
-            bytes[i] = (byte)('0' + value % 10);
+        while (digits-- > 0) {
+            bytes[offset + digits] = (byte)('0' + value % 10);
 
             value /= 10;
         }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -532,7 +532,7 @@ public class FIXValue {
      * @param x a checksum
      */
     public void setCheckSum(long x) {
-        setDigits(x & 0xff, 0, 3);
+        setDigits((int)(x & 0xff), 0, 3);
         bytes[3] = SOH;
 
         offset = 0;
@@ -594,11 +594,11 @@ public class FIXValue {
         return value;
     }
 
-    private void setDigits(long l, int offset, int digits) {
+    private void setDigits(int value, int offset, int digits) {
         for (int i = offset + digits - 1; i >= offset; i--) {
-            bytes[i] = (byte)('0' + l % 10);
+            bytes[i] = (byte)('0' + value % 10);
 
-            l /= 10;
+            value /= 10;
         }
     }
 


### PR DESCRIPTION
Change an argument type and eliminate a variable to decrease the bytecode size of the method from 44 bytes to 31 bytes, which is within HotSpot's default maximum inline size of 35 bytes.