### PR TITLE
philadelphia-core: Improve backing store management

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
@@ -30,7 +30,7 @@ public class FIXConfig {
     private final long       outgoingMsgSeqNum;
     private final int        maxFieldCount;
     private final int        fieldCapacity;
-    private final int        chunkSize;
+    private final int        blockSize;
     private final int        rxBufferCapacity;
     private final int        txBufferCapacity;
     private final boolean    checkSumEnabled;
@@ -46,7 +46,7 @@ public class FIXConfig {
      * @param outgoingMsgSeqNum the outgoing MsgSeqNum(34)
      * @param maxFieldCount the maximum number of fields in a message
      * @param fieldCapacity the field capacity
-     * @param chunkSize the backing store chunk size
+     * @param blockSize the backing store block size
      * @param rxBufferCapacity the receive buffer capacity
      * @param txBufferCapacity the transmit buffer capacity
      * @param checkSumEnabled the incoming CheckSum(10) check status
@@ -55,7 +55,7 @@ public class FIXConfig {
     public FIXConfig(FIXVersion version, String senderCompId,
             String targetCompId, int heartBtInt,
             long incomingMsgSeqNum, long outgoingMsgSeqNum,
-            int maxFieldCount, int fieldCapacity, int chunkSize,
+            int maxFieldCount, int fieldCapacity, int blockSize,
             int rxBufferCapacity, int txBufferCapacity,
             boolean checkSumEnabled) {
         this.version           = version;
@@ -66,7 +66,7 @@ public class FIXConfig {
         this.outgoingMsgSeqNum = outgoingMsgSeqNum;
         this.maxFieldCount     = maxFieldCount;
         this.fieldCapacity     = fieldCapacity;
-        this.chunkSize         = chunkSize;
+        this.blockSize         = blockSize;
         this.rxBufferCapacity  = rxBufferCapacity;
         this.txBufferCapacity  = txBufferCapacity;
         this.checkSumEnabled   = checkSumEnabled;
@@ -145,12 +145,12 @@ public class FIXConfig {
     }
 
     /**
-     * Get the backing store chunk size.
+     * Get the backing store block size.
      *
-     * @return the backing store chunk size
+     * @return the backing store block size
      */
-    public int getChunkSize() {
-        return chunkSize;
+    public int getBlockSize() {
+        return blockSize;
     }
 
     /**
@@ -216,7 +216,7 @@ public class FIXConfig {
      *   <li>outgoing MsgSeqNum(34): 1</li>
      *   <li>maximum number of fields in a message: 64</li>
      *   <li>field capacity: 64</li>
-     *   <li>backing store chunk size: 4096</li>
+     *   <li>backing store block size: 4096</li>
      *   <li>receive buffer capacity: 1024</li>
      *   <li>transmit buffer capacity: 1024</li>
      *   <li>incoming CheckSum(10) check status: enabled</li>
@@ -232,7 +232,7 @@ public class FIXConfig {
         private long       outgoingMsgSeqNum;
         private int        maxFieldCount;
         private int        fieldCapacity;
-        private int        chunkSize;
+        private int        blockSize;
         private int        rxBufferCapacity;
         private int        txBufferCapacity;
         private boolean    checkSumEnabled;
@@ -249,7 +249,7 @@ public class FIXConfig {
             outgoingMsgSeqNum = 1;
             maxFieldCount     = 64;
             fieldCapacity     = 64;
-            chunkSize         = 4096;
+            blockSize         = 4096;
             rxBufferCapacity  = 1024;
             txBufferCapacity  = 1024;
             checkSumEnabled   = true;
@@ -352,13 +352,13 @@ public class FIXConfig {
         }
 
         /**
-         * Set the chunk size.
+         * Set the block size.
          *
-         * @param chunkSize the chunk size
+         * @param blockSize the block size
          * @return this instance
          */
-        public Builder setChunkSize(int chunkSize) {
-            this.chunkSize = chunkSize;
+        public Builder setBlockSize(int blockSize) {
+            this.blockSize = blockSize;
 
             return this;
         }
@@ -408,7 +408,7 @@ public class FIXConfig {
         public FIXConfig build() {
             return new FIXConfig(version, senderCompId, targetCompId,
                     heartBtInt, incomingMsgSeqNum, outgoingMsgSeqNum,
-                    maxFieldCount, fieldCapacity, chunkSize,
+                    maxFieldCount, fieldCapacity, blockSize,
                     rxBufferCapacity, txBufferCapacity,
                     checkSumEnabled);
         }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
@@ -30,6 +30,7 @@ public class FIXConfig {
     private final long       outgoingMsgSeqNum;
     private final int        maxFieldCount;
     private final int        fieldCapacity;
+    private final int        chunkSize;
     private final int        rxBufferCapacity;
     private final int        txBufferCapacity;
     private final boolean    checkSumEnabled;
@@ -45,6 +46,7 @@ public class FIXConfig {
      * @param outgoingMsgSeqNum the outgoing MsgSeqNum(34)
      * @param maxFieldCount the maximum number of fields in a message
      * @param fieldCapacity the field capacity
+     * @param chunkSize the backing store chunk size
      * @param rxBufferCapacity the receive buffer capacity
      * @param txBufferCapacity the transmit buffer capacity
      * @param checkSumEnabled the incoming CheckSum(10) check status
@@ -53,8 +55,9 @@ public class FIXConfig {
     public FIXConfig(FIXVersion version, String senderCompId,
             String targetCompId, int heartBtInt,
             long incomingMsgSeqNum, long outgoingMsgSeqNum,
-            int maxFieldCount, int fieldCapacity, int rxBufferCapacity,
-            int txBufferCapacity, boolean checkSumEnabled) {
+            int maxFieldCount, int fieldCapacity, int chunkSize,
+            int rxBufferCapacity, int txBufferCapacity,
+            boolean checkSumEnabled) {
         this.version           = version;
         this.senderCompId      = senderCompId;
         this.targetCompId      = targetCompId;
@@ -63,6 +66,7 @@ public class FIXConfig {
         this.outgoingMsgSeqNum = outgoingMsgSeqNum;
         this.maxFieldCount     = maxFieldCount;
         this.fieldCapacity     = fieldCapacity;
+        this.chunkSize         = chunkSize;
         this.rxBufferCapacity  = rxBufferCapacity;
         this.txBufferCapacity  = txBufferCapacity;
         this.checkSumEnabled   = checkSumEnabled;
@@ -141,6 +145,15 @@ public class FIXConfig {
     }
 
     /**
+     * Get the backing store chunk size.
+     *
+     * @return the backing store chunk size
+     */
+    public int getChunkSize() {
+        return chunkSize;
+    }
+
+    /**
      * Get the receive buffer capacity.
      *
      * @return the receive buffer capacity
@@ -203,6 +216,7 @@ public class FIXConfig {
      *   <li>outgoing MsgSeqNum(34): 1</li>
      *   <li>maximum number of fields in a message: 64</li>
      *   <li>field capacity: 64</li>
+     *   <li>backing store chunk size: 4096</li>
      *   <li>receive buffer capacity: 1024</li>
      *   <li>transmit buffer capacity: 1024</li>
      *   <li>incoming CheckSum(10) check status: enabled</li>
@@ -218,6 +232,7 @@ public class FIXConfig {
         private long       outgoingMsgSeqNum;
         private int        maxFieldCount;
         private int        fieldCapacity;
+        private int        chunkSize;
         private int        rxBufferCapacity;
         private int        txBufferCapacity;
         private boolean    checkSumEnabled;
@@ -234,6 +249,7 @@ public class FIXConfig {
             outgoingMsgSeqNum = 1;
             maxFieldCount     = 64;
             fieldCapacity     = 64;
+            chunkSize         = 4096;
             rxBufferCapacity  = 1024;
             txBufferCapacity  = 1024;
             checkSumEnabled   = true;
@@ -336,6 +352,18 @@ public class FIXConfig {
         }
 
         /**
+         * Set the chunk size.
+         *
+         * @param chunkSize the chunk size
+         * @return this instance
+         */
+        public Builder setChunkSize(int chunkSize) {
+            this.chunkSize = chunkSize;
+
+            return this;
+        }
+
+        /**
          * Set the receive buffer capacity.
          *
          * @param rxBufferCapacity the receive buffer capacity
@@ -380,8 +408,9 @@ public class FIXConfig {
         public FIXConfig build() {
             return new FIXConfig(version, senderCompId, targetCompId,
                     heartBtInt, incomingMsgSeqNum, outgoingMsgSeqNum,
-                    maxFieldCount, fieldCapacity, rxBufferCapacity,
-                    txBufferCapacity, checkSumEnabled);
+                    maxFieldCount, fieldCapacity, chunkSize,
+                    rxBufferCapacity, txBufferCapacity,
+                    checkSumEnabled);
         }
 
     }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
@@ -41,7 +41,7 @@ public class FIXMessage {
      * @param config the message configuration
      */
     public FIXMessage(FIXConfig config) {
-        this(config.getMaxFieldCount(), config.getFieldCapacity(), config.getChunkSize());
+        this(config.getMaxFieldCount(), config.getFieldCapacity(), config.getBlockSize());
     }
 
     /**
@@ -51,7 +51,7 @@ public class FIXMessage {
      * @param fieldCapacity the field capacity
      */
     public FIXMessage(int maxFieldCount, int fieldCapacity) {
-        this(maxFieldCount, fieldCapacity, DEFAULTS.getChunkSize());
+        this(maxFieldCount, fieldCapacity, DEFAULTS.getBlockSize());
     }
 
     /**
@@ -59,22 +59,22 @@ public class FIXMessage {
      *
      * @param maxFieldCount the maximum number of fields
      * @param fieldCapacity the field capacity
-     * @param chunkSize the backing store chunk size
+     * @param blockSize the backing store block size
      */
-    public FIXMessage(int maxFieldCount, int fieldCapacity, int chunkSize) {
+    public FIXMessage(int maxFieldCount, int fieldCapacity, int blockSize) {
         tags = new int[maxFieldCount];
 
         values = new FIXValue[maxFieldCount];
 
-        byte[] bytes = new byte[chunkSize];
+        byte[] bytes = new byte[blockSize];
 
         int start = 0;
 
         for (int i = 0; i < values.length; i++) {
             int end = start + fieldCapacity;
 
-            if (end > chunkSize) {
-                bytes = new byte[chunkSize];
+            if (end > blockSize) {
+                bytes = new byte[blockSize];
 
                 start = 0;
                 end   = fieldCapacity;

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -28,7 +28,9 @@ public class FIXValueTest {
 
     @Before
     public void setUp() {
-        value = new FIXValue(32);
+        byte[] bytes = new byte[64];
+
+        value = new FIXValue(bytes, 16, 48);
     }
 
     @Test


### PR DESCRIPTION
Start using shared backing arrays for value containers.

Allocate one or more backing arrays, called _chunks_, per message container. Introduce a new configuration option, `chunkSize`, to specify the size of one such backing array.

In order to enable this, first make it possible to specify a backing array for a value container.

Add two new internal attributes: `start` and `end`. These are the start index (inclusive) and the end index (exclusive) for the value container's slot in the backing array.

The existing internal attributes `offset` and `length` retain the same semantics as before. In particular, `offset` still refers to the position of the contained value within the entire backing array  and is not relative to `start`.

Because `offset` and `length` work the same way as before, the value accessors, such as `FIXValue#asBoolean`, do not change. However, the value mutators, such as `FIXValue#setBoolean` do change: the value container's slot in the backing array now starts at `start` instead of 0 and ends at `end` instead of `bytes.length`.

The bytecode changes are as follows:

Method | Before | After | Change
-|-|-|-
`set` | 41 | 41 | 0
`setBoolean` | 34 | 45 | +11
`setChar` | 25 | 36 | +11
`setInt` | 102 | 99 | -3
`setFloat` | 177 | 174 | -3
`setString` | 55 | 68 | +13
`setDate` | 59 | 80 | +21
`setTimeOnly` | 119 | 165 | +46
`setTimestamp` | 172 | 238 | +66
`setCheckSum` | 28 | 39 | +11
`get` | 65 | 67 | +2

The hope is that improved data locality will produce performance gains despite the overhead of increased code complexity. However, detailed performance testing is still to be done.