### PR TITLE
philadelphia-core: Optimize 'FIXTimestamps#setDigits'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamps.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamps.java
@@ -52,8 +52,8 @@ public class FIXTimestamps {
     }
 
     private static void setDigits(char[] buffer, int i, int offset, int digits) {
-        for (int j = offset + digits - 1; j >= offset; j--) {
-            buffer[j] = (char)('0' + i % 10);
+        while (digits-- > 0) {
+            buffer[offset + digits] = (char)('0' + i % 10);
 
             i /= 10;
         }


### PR DESCRIPTION
This decreases the bytecode size of the method from 36 to 28 bytes, which is within HotSpot's default maximum inline size of 35 bytes.