### PR TITLE
philadelphia-core: Improve buffer capacity management

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
@@ -204,8 +204,7 @@ class TerminalClient implements Closeable {
             .setHeartBtInt(heartBtInt)
             .setMaxFieldCount(1024)
             .setFieldCapacity(1024)
-            .setRxBufferCapacity(1024 * 1024)
-            .setTxBufferCapacity(1024 * 1024);
+            .setBufferCapacity(1024 * 1024);
 
         TerminalClient.open(new InetSocketAddress(address, port), builder.build()).run(lines);
     }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
@@ -141,11 +141,21 @@ public class FIXConfig {
     }
 
     /**
+     * Get the buffer capacity.
+     *
+     * @return the buffer capacity
+     */
+    public int getBufferCapacity() {
+        return Math.max(rxBufferCapacity, txBufferCapacity);
+    }
+
+    /**
      * Get the receive buffer capacity.
      *
      * @return the receive buffer capacity
+     * @deprecated Use {@link #getBufferCapacity()} instead.
      */
-
+    @Deprecated
     public int getRxBufferCapacity() {
         return rxBufferCapacity;
     }
@@ -154,7 +164,9 @@ public class FIXConfig {
      * Get the transmit buffer capacity.
      *
      * @return the transmit buffer capacity
+     * @deprecated Use {@link #getBufferCapacity()} instead.
      */
+    @Deprecated
     public int getTxBufferCapacity() {
         return txBufferCapacity;
     }
@@ -336,11 +348,26 @@ public class FIXConfig {
         }
 
         /**
+         * Set the buffer capacity.
+         *
+         * @param bufferCapacity the buffer capacity
+         * @return this instance
+         */
+        public Builder setBufferCapacity(int bufferCapacity) {
+            this.rxBufferCapacity = bufferCapacity;
+            this.txBufferCapacity = bufferCapacity;
+
+            return this;
+        }
+
+        /**
          * Set the receive buffer capacity.
          *
          * @param rxBufferCapacity the receive buffer capacity
          * @return this instance
+         * @deprecated Use {@link #setBufferCapacity(int)} instead.
          */
+        @Deprecated
         public Builder setRxBufferCapacity(int rxBufferCapacity) {
             this.rxBufferCapacity = rxBufferCapacity;
 
@@ -352,7 +379,9 @@ public class FIXConfig {
          *
          * @param txBufferCapacity the transmit buffer capacity
          * @return this instance
+         * @deprecated Use {@link #setBufferCapacity(int)} instead.
          */
+        @Deprecated
         public Builder setTxBufferCapacity(int txBufferCapacity) {
             this.txBufferCapacity = txBufferCapacity;
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -120,9 +120,9 @@ public class FIXConnection implements Closeable {
         this.rxMsgSeqNum = config.getIncomingMsgSeqNum();
         this.txMsgSeqNum = config.getOutgoingMsgSeqNum();
 
-        this.rxBuffer = ByteBuffer.allocateDirect(config.getRxBufferCapacity());
+        this.rxBuffer = ByteBuffer.allocateDirect(config.getBufferCapacity());
 
-        this.txHeaderBuffer = ByteBuffer.allocateDirect(config.getTxBufferCapacity());
+        this.txHeaderBuffer = ByteBuffer.allocateDirect(config.getBufferCapacity());
 
         FIXValue beginString = new FIXValue(BEGIN_STRING_FIELD_CAPACITY);
 
@@ -134,7 +134,7 @@ public class FIXConnection implements Closeable {
 
         this.bodyLengthOffset = this.txHeaderBuffer.position();
 
-        this.txBodyBuffer = ByteBuffer.allocateDirect(config.getTxBufferCapacity());
+        this.txBodyBuffer = ByteBuffer.allocateDirect(config.getBufferCapacity());
 
         this.txBuffers = new ByteBuffer[2];
 


### PR DESCRIPTION
Add `FIXConfig#getBufferCapacity()` and deprecate the following methods:

  - `FIXConfig#getRxBufferCapacity()`
  - `FIXConfig#getTxBufferCapacity()`

The purpose of this change is to simplify configuration. As the maximum number of fields and the field capacity already apply to both incoming and outgoing messages, it makes sense to have one buffer capacity that applies to both as well.

The deprecated methods will continue working as before until they get removed in Philadelphia 2.0.0.