### PR TITLE
philadelphia-core: Optimize 'FIXValue#setInt' and 'FIXValue#setFloat'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -399,32 +399,32 @@ public class FIXValue {
      * @see #asFloat
      */
     public void setFloat(double x, int decimals) {
-        bytes[end - 1] = SOH;
+        int i = end;
+
+        bytes[--i] = SOH;
 
         long y = Math.round(POWERS_OF_TEN[decimals] * Math.abs(x));
 
-        int i = end - 2;
-
         for (int j = 0; j < decimals; j++) {
-            bytes[i--] = (byte)('0' + y % 10);
+            bytes[--i] = (byte)('0' + y % 10);
 
             y /= 10;
         }
 
         if (decimals > 0)
-            bytes[i--] = '.';
+            bytes[--i] = '.';
 
         do {
-            bytes[i--] = (byte)('0' + y % 10);
+            bytes[--i] = (byte)('0' + y % 10);
 
             y /= 10;
         } while (y > 0);
 
         if (x < 0)
-            bytes[i--] = '-';
+            bytes[--i] = '-';
 
-        offset = i + 1;
-        length = end - 1 - offset;
+        offset = i;
+        length = end - offset - 1;
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -283,23 +283,23 @@ public class FIXValue {
      * @param x an integer
      */
     public void setInt(long x) {
-        bytes[end - 1] = SOH;
+        int i = end;
+
+        bytes[--i] = SOH;
 
         long y = Math.abs(x);
 
-        int i = end - 2;
-
         do {
-            bytes[i--] = (byte)('0' + y % 10);
+            bytes[--i] = (byte)('0' + y % 10);
 
             y /= 10;
         } while (y > 0);
 
         if (x < 0)
-            bytes[i--] = '-';
+            bytes[--i] = '-';
 
-        offset = i + 1;
-        length = end - 1 - offset;
+        offset = i;
+        length = end - offset - 1;
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -53,6 +53,8 @@ public class FIXValue {
 
     private final byte[] bytes;
 
+    private final int end;
+
     private int offset;
     private int length;
 
@@ -63,6 +65,8 @@ public class FIXValue {
      */
     public FIXValue(int capacity) {
         bytes = new byte[capacity];
+
+        end = capacity;
 
         bytes[0] = SOH;
 
@@ -279,11 +283,11 @@ public class FIXValue {
      * @param x an integer
      */
     public void setInt(long x) {
-        bytes[bytes.length - 1] = SOH;
+        bytes[end - 1] = SOH;
 
         long y = Math.abs(x);
 
-        int i = bytes.length - 2;
+        int i = end - 2;
 
         do {
             bytes[i--] = (byte)('0' + y % 10);
@@ -295,7 +299,7 @@ public class FIXValue {
             bytes[i--] = '-';
 
         offset = i + 1;
-        length = bytes.length - 1 - offset;
+        length = end - 1 - offset;
     }
 
     /**
@@ -378,11 +382,11 @@ public class FIXValue {
      * @see #asFloat
      */
     public void setFloat(double x, int decimals) {
-        bytes[bytes.length - 1] = SOH;
+        bytes[end - 1] = SOH;
 
         long y = Math.round(POWERS_OF_TEN[decimals] * Math.abs(x));
 
-        int i = bytes.length - 2;
+        int i = end - 2;
 
         for (int j = 0; j < decimals; j++) {
             bytes[i--] = (byte)('0' + y % 10);
@@ -403,7 +407,7 @@ public class FIXValue {
             bytes[i--] = '-';
 
         offset = i + 1;
-        length = bytes.length - 1 - offset;
+        length = end - 1 - offset;
     }
 
     /**
@@ -641,7 +645,7 @@ public class FIXValue {
             if (b == SOH)
                 return true;
 
-            if (++length == bytes.length)
+            if (++length == end)
                 tooLongValue();
         }
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -283,20 +283,37 @@ public class FIXValue {
      * @param x an integer
      */
     public void setInt(long x) {
+        if (x < 0) {
+            setNegativeInt(x);
+            return;
+        }
+
         int i = end;
 
         bytes[--i] = SOH;
 
-        long y = Math.abs(x);
+        do {
+            bytes[--i] = (byte)('0' + x % 10);
+
+            x /= 10;
+        } while (x > 0);
+
+        offset = i;
+        length = end - offset - 1;
+    }
+
+    private void setNegativeInt(long x) {
+        int i = end;
+
+        bytes[--i] = SOH;
 
         do {
-            bytes[--i] = (byte)('0' + y % 10);
+            bytes[--i] = (byte)('0' - x % 10);
 
-            y /= 10;
-        } while (y > 0);
+            x /= 10;
+        } while (x < 0);
 
-        if (x < 0)
-            bytes[--i] = '-';
+        bytes[--i] = '-';
 
         offset = i;
         length = end - offset - 1;

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -399,11 +399,16 @@ public class FIXValue {
      * @see #asFloat
      */
     public void setFloat(double x, int decimals) {
+        if (x < 0.0) {
+            setNegativeFloat(x, decimals);
+            return;
+        }
+
         int i = end;
 
         bytes[--i] = SOH;
 
-        long y = Math.round(POWERS_OF_TEN[decimals] * Math.abs(x));
+        long y = Math.round(POWERS_OF_TEN[decimals] * x);
 
         for (int j = 0; j < decimals; j++) {
             bytes[--i] = (byte)('0' + y % 10);
@@ -420,8 +425,33 @@ public class FIXValue {
             y /= 10;
         } while (y > 0);
 
-        if (x < 0)
-            bytes[--i] = '-';
+        offset = i;
+        length = end - offset - 1;
+    }
+
+    private void setNegativeFloat(double x, int decimals) {
+        int i = end;
+
+        bytes[--i] = SOH;
+
+        long y = Math.round(POWERS_OF_TEN[decimals] * -x);
+
+        for (int j = 0; j < decimals; j++) {
+            bytes[--i] = (byte)('0' + y % 10);
+
+            y /= 10;
+        }
+
+        if (decimals > 0)
+            bytes[--i] = '.';
+
+        do {
+            bytes[--i] = (byte)('0' + y % 10);
+
+            y /= 10;
+        } while (y > 0);
+
+        bytes[--i] = '-';
 
         offset = i;
         length = end - offset - 1;


### PR DESCRIPTION
Optimize handling of positive numbers at the expense of negative numbers. This decreases the bytecode sizes of the methods as follows:

Method | Before | After
-|-|-
`setInt` | 102 | 79
`setFloat` | 177 | 161

The impact on the microbenchmarks is negligible.