### PR TITLE
philadelphia-core: Improve 'FIXMessageParser'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageParser.java
@@ -31,7 +31,6 @@ public class FIXMessageParser {
 
     private final boolean checkSumEnabled;
 
-    private final FIXValue beginString;
     private final FIXValue bodyLength;
     private final FIXValue checkSum;
 
@@ -48,9 +47,8 @@ public class FIXMessageParser {
 
         this.listener = listener;
 
-        this.beginString = new FIXValue(BEGIN_STRING_FIELD_CAPACITY);
-        this.bodyLength  = new FIXValue(BODY_LENGTH_FIELD_CAPACITY);
-        this.checkSum    = new FIXValue(CHECK_SUM_FIELD_CAPACITY);
+        this.bodyLength = new FIXValue(BODY_LENGTH_FIELD_CAPACITY);
+        this.checkSum   = new FIXValue(CHECK_SUM_FIELD_CAPACITY);
     }
 
     /**
@@ -77,7 +75,7 @@ public class FIXMessageParser {
             garbled = buffer.get() != '8' || buffer.get() != '=';
 
             // Partial message
-            if (!beginString.get(buffer)) {
+            if (!skipValue(buffer)) {
                 buffer.reset();
 
                 return false;
@@ -166,6 +164,15 @@ public class FIXMessageParser {
         buffer.position(position);
 
         return true;
+    }
+
+    private static boolean skipValue(ByteBuffer buffer) {
+        while (buffer.hasRemaining()) {
+            if (buffer.get() == SOH)
+                return true;
+        }
+
+        return false;
     }
 
 }


### PR DESCRIPTION
Inline parsing of the BeginString(8) value. This makes message parsing 5.3% faster in the performance test when the incoming CheckSum(10) check is disabled and 4.1% faster when it is enabled.