### PR TITLE
philadelphia-generate: Require Python 3.6 or newer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.5
           - 3.6
           - 3.7
           - 3.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           - 3.6
           - 3.7
           - 3.8
+          - 3.9
     steps:
       - name: Check out GitHub repository
         uses: actions/checkout@v2

--- a/applications/generate/README.md
+++ b/applications/generate/README.md
@@ -3,7 +3,7 @@
 Philadelphia Code Generator is a simple console application for generating
 Philadelphia profiles for FIX dialects.
 
-Philadelphia Code Generator requires Python 3.5 or newer.
+Philadelphia Code Generator requires Python 3.6 or newer.
 
 ## Features
 

--- a/scripts/generate
+++ b/scripts/generate
@@ -22,7 +22,7 @@
 #   https://www.fixtrading.org/standards/fix-repository/
 #
 # This script uses Philadelphia Code Generator and therefore requires Python
-# 3.5 or newer.
+# 3.6 or newer.
 #
 # As this repository already contains the generated FIX protocol versions, you
 # only need to run this script if you change Philadelphia Code Generator or add

--- a/scripts/generate-fixlatest
+++ b/scripts/generate-fixlatest
@@ -22,7 +22,7 @@
 #   https://www.fixtrading.org/standards/fix-orchestra/
 #
 # This script uses Philadelphia Code Generator and therefore requires Python
-# 3.5 or newer.
+# 3.6 or newer.
 #
 # As this repository already contains FIX Latest, you only need to run this
 # script if FIX Latest updates or you change Philadelphia Code Generator.


### PR DESCRIPTION
Python 3.5 has reached end-of-life.