### PR TITLE
philadelphia-core: Improve 'FIXValue#toString'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
@@ -317,7 +317,8 @@ public class FIXMessage {
         for (int i = 0; i < count; i++) {
             builder.append(tags[i]);
             builder.append('=');
-            values[i].toString(builder);
+            values[i].asString(builder);
+            builder.append('|');
         }
     }
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -720,22 +720,7 @@ public class FIXValue {
      */
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-
-        toString(builder);
-
-        return builder.toString();
-    }
-
-    /**
-     * Appends a string representation of this value to the specified string
-     * builder.
-     *
-     * @param builder a string builder
-     */
-    public void toString(StringBuilder builder) {
-        asString(builder);
-        builder.append('|');
+        return asString();
     }
 
     private int getDigits(int digits, int offset) {

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -808,18 +808,7 @@ class FIXValueTest {
     void string() {
         value.setString("FOO");
 
-        assertEquals("FOO|", value.toString());
-    }
-
-    @Test
-    void stringWithStringBuilder() {
-        value.setString("FOO");
-
-        StringBuilder builder = new StringBuilder();
-
-        value.toString(builder);
-
-        assertEquals("FOO|", builder.toString());
+        assertEquals("FOO", value.toString());
     }
 
     private boolean get(String text) {


### PR DESCRIPTION
Remove the pipe character (`|`) from the `FIXValue#toString()` return value. As this means that the return value of this method will be equal to the return value of the `FIXValue#asString()` method, remove the `FIXValue#toString(StringBuilder)` method as it becomes effectively a duplicate of the `FIXValue#asString(StringBuilder)` method.

Philadelphia uses the pipe character as a human-readable stand-in for the non-printable SOH character, which terminates a value in the FIX protocol. Although it is a part of the internal data representation in the `FIXValue` class, I feel that aligning the `toString` method to the `asString` method makes much more sense for most use cases of this method.

As this method was added after the most recent release, 1.2.0, this change will have no impact on existing Philadelphia applications.