### PR TITLE
philadelphia-core: Remove 'FIXTimestamps.setDigits' optimization

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamps.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamps.java
@@ -52,8 +52,8 @@ public class FIXTimestamps {
     }
 
     private static void setDigits(char[] buffer, int i, int offset, int digits) {
-        while (digits-- > 0) {
-            buffer[offset + digits] = (char)('0' + i % 10);
+        for (int j = offset + digits - 1; j >= offset; j--) {
+            buffer[j] = (char)('0' + i % 10);
 
             i /= 10;
         }


### PR DESCRIPTION
Although the original change decreases the bytecode size of the method from 36 to 28 bytes, which is within HotSpot's default maximum inline size of 35 bytes, this appears to cause a 1-2% performance regression when HotSpot has fully optimized this code. Fix this by removing the bytecode optimization.

This reverts commit 1571bf60bbba825fd216794a3d09bb0f41092a29.