### PR TITLE
philadelphia-core: Remove 'FIXValue#setDigits' optimization

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -739,8 +739,8 @@ public class FIXValue {
     }
 
     private void setDigits(int value, int offset, int digits) {
-        while (digits-- > 0) {
-            bytes[offset + digits] = (byte)('0' + value % 10);
+        for (int i = offset + digits - 1; i >= offset; i--) {
+            bytes[i] = (byte)('0' + value % 10);
 
             value /= 10;
         }


### PR DESCRIPTION
Although the original change decreases the bytecode size of the method from 39 to 31 bytes, which is within HotSpot's default maximum inline size of 35 bytes, this appears to cause a 1-2% performance regression when HotSpot has fully optimized this code. Fix this by removing the bytecode optimization.

This reverts commit 64c68f47d57e833613a531cc7429a6d59ec23f3a.