### PR TITLE
philadelphia-core: Fix EndSeqNo(16) handling

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -206,6 +206,10 @@ public class FIXConnection implements Closeable {
         return txMsgSeqNum;
     }
 
+    void setOutgoingMsgSeqNum(long outgoingMsgSeqNum) {
+        txMsgSeqNum = outgoingMsgSeqNum;
+    }
+
     /**
      * Get the SenderCompID(49).
      *
@@ -607,13 +611,16 @@ public class FIXConnection implements Closeable {
                 return;
             }
 
-            FIXValue endSeqNo = message.valueOf(EndSeqNo);
-            if (endSeqNo == null) {
+            FIXValue value = message.valueOf(EndSeqNo);
+            if (value == null) {
                 sendReject(message.getMsgSeqNum(), RequiredTagMissing, "EndSeqNo(16) not found");
                 return;
             }
 
-            sendSequenceReset(beginSeqNo, endSeqNo.asInt() + 1);
+            long endSeqNo = value.asInt();
+            long newSeqNo = endSeqNo == 0 ? txMsgSeqNum : endSeqNo + 1;
+
+            sendSequenceReset(beginSeqNo, newSeqNo);
         }
 
         private void handleReject(FIXMessage message) throws IOException {

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -628,7 +628,7 @@ public class FIXConnection implements Closeable {
                 return;
             }
 
-            long newSeqNo = endSeqNo == 0 ? txMsgSeqNum : endSeqNo + 1;
+            long newSeqNo = endSeqNo == 0 ? txMsgSeqNum : Math.min(endSeqNo + 1, txMsgSeqNum);
 
             sendSequenceReset(beginSeqNo, newSeqNo);
         }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -238,10 +238,21 @@ class FIXInitiatorTest {
     }
 
     @Test
-    void receiveResendRequest() throws IOException {
+    void receiveResendRequestWithNonZeroEndSeqNo() throws IOException {
         String request  = "35=2|34=1|7=2|16=4|";
         String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
             "52=19700101-00:00:00.000|123=Y|36=5|10=231|";
+
+        acceptorRequestInitiatorResponse(request, response);
+    }
+
+    @Test
+    void receiveResendRequestWithZeroEndSeqNo() throws IOException {
+        initiator.setOutgoingMsgSeqNum(3);
+
+        String request  = "35=2|34=1|7=2|16=0|";
+        String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
+            "52=19700101-00:00:00.000|123=Y|36=3|10=229|";
 
         acceptorRequestInitiatorResponse(request, response);
     }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -239,6 +239,8 @@ class FIXInitiatorTest {
 
     @Test
     void receiveResendRequestWithNonZeroEndSeqNo() throws IOException {
+        initiator.setOutgoingMsgSeqNum(2);
+
         String request  = "35=2|34=1|7=2|16=4|";
         String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
             "52=19700101-00:00:00.000|123=Y|36=5|10=231|";
@@ -271,6 +273,15 @@ class FIXInitiatorTest {
         String request  = "35=2|34=1|7=1|";
         String response = "8=FIX.4.2|9=97|35=3|49=initiator|56=acceptor|34=1|" +
             "52=19700101-00:00:00.000|45=1|373=1|58=EndSeqNo(16) not found|10=213|";
+
+        acceptorRequestInitiatorResponse(request, response);
+    }
+
+    @Test
+    void receiveResendRequestWithTooHighBeginSeqNo() throws IOException {
+        String request  = "35=2|34=1|7=2|16=0|";
+        String response = "8=FIX.4.2|9=97|35=3|49=initiator|56=acceptor|34=1|" +
+            "52=19700101-00:00:00.000|45=1|373=5|58=BeginSeqNo(7) too high|10=252|";
 
         acceptorRequestInitiatorResponse(request, response);
     }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -239,7 +239,7 @@ class FIXInitiatorTest {
 
     @Test
     void receiveResendRequestWithNonZeroEndSeqNo() throws IOException {
-        initiator.setOutgoingMsgSeqNum(2);
+        initiator.setOutgoingMsgSeqNum(5);
 
         String request  = "35=2|34=1|7=2|16=4|";
         String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
@@ -282,6 +282,17 @@ class FIXInitiatorTest {
         String request  = "35=2|34=1|7=2|16=0|";
         String response = "8=FIX.4.2|9=97|35=3|49=initiator|56=acceptor|34=1|" +
             "52=19700101-00:00:00.000|45=1|373=5|58=BeginSeqNo(7) too high|10=252|";
+
+        acceptorRequestInitiatorResponse(request, response);
+    }
+
+    @Test
+    void receiveResendRequestWithTooHighEndSeqNo() throws IOException {
+        initiator.setOutgoingMsgSeqNum(3);
+
+        String request  = "35=2|34=1|7=2|16=5|";
+        String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
+            "52=19700101-00:00:00.000|123=Y|36=3|10=229|";
 
         acceptorRequestInitiatorResponse(request, response);
     }


### PR DESCRIPTION
The value 0 for the EndSeqNo(16) field in a ResendRequest(2) message should represent infinity and correspond to all subsequent messages after the message referred to by the BeginSeqNo(7) field.

As noticed by @mhartememx, the handling for this value is currently broken. Fix this.