### PR TITLE
philadelphia-core: Restore 'FIXTimestamps.setDigits' and 'FIXValue#setDigits' optimizations

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamps.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamps.java
@@ -52,8 +52,8 @@ public class FIXTimestamps {
     }
 
     private static void setDigits(char[] buffer, int i, int offset, int digits) {
-        for (int j = offset + digits - 1; j >= offset; j--) {
-            buffer[j] = (char)('0' + i % 10);
+        while (digits-- > 0) {
+            buffer[offset + digits] = (char)('0' + i % 10);
 
             i /= 10;
         }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -739,8 +739,8 @@ public class FIXValue {
     }
 
     private void setDigits(int value, int offset, int digits) {
-        for (int i = offset + digits - 1; i >= offset; i--) {
-            bytes[i] = (byte)('0' + value % 10);
+        while (digits-- > 0) {
+            bytes[offset + digits] = (byte)('0' + value % 10);
 
             value /= 10;
         }


### PR DESCRIPTION
Due to an [error in the `format-perf-test` script](https://github.com/paritytrading/philadelphia/pull/186), performance improvements got misclassified as performance regressions and subsequently removed. Restore these optimizations.

This reverts commits 26489ce and a1197f5.