### PR TITLE
philadelphia-core: Remove 'FIXValue#asCheckSum'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -647,18 +647,6 @@ public class FIXValue {
     }
 
     /**
-     * Get the value as a checksum.
-     *
-     * @return the value as a checksum
-     * @throws FIXValueFormatException if the value is not an integer
-     * @deprecated Use {@link #asInt()} instead.
-     */
-    @Deprecated
-    public long asCheckSum() {
-        return asInt();
-    }
-
-    /**
      * Set the value to a checksum.
      *
      * @param x a checksum

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -764,22 +764,6 @@ class FIXValueTest {
         assertEquals("20150924-09:30:05\u0001", put());
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    void asCheckSum() {
-        get("064\u0001");
-
-        assertEquals(64, value.asCheckSum());
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test
-    void notCheckSum() {
-        value.setString("FOO");
-
-        assertThrows(FIXValueFormatException.class, () -> value.asCheckSum());
-    }
-
     @Test
     void setCheckSum() {
         value.setCheckSum(320);


### PR DESCRIPTION
This method is deprecated. Remove it as a part of the next major version, Philadelphia 2.0.0.