### PR TITLE
scripts: Add 'build-baseline' and 'build-candidate' scripts

### DIFF
--- a/scripts/build-baseline
+++ b/scripts/build-baseline
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Philadelphia authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This script builds Philadelphia Performance Test for the latest release and
+# copies it under the name 'baseline.jar'.
+#
+# Run this script as follows:
+#
+#   ./scripts/build-baseline
+#
+
+set -e
+
+filename="baseline.jar"
+
+if [[ -e "$filename" ]]; then
+    echo "error: $filename: File exists" >&2
+    exit 1
+fi
+
+version=$(git for-each-ref --count=1 --format="%(refname:lstrip=2)" "refs/tags" \
+    --sort=-version:refname)
+
+echo -n "Using Philadelphia $version for '$filename'. Proceed? [y/n] "
+read -r response
+
+if [[ $response != "y" ]]; then
+    exit 1
+fi
+
+git checkout -q "$version"
+
+echo "Building '$filename'..."
+
+mvn -q clean package -am -pl tests/perf-test
+cp tests/perf-test/philadelphia-perf-test.jar "$filename"
+
+git checkout -q -

--- a/scripts/build-candidate
+++ b/scripts/build-candidate
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Philadelphia authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This script builds Philadelphia Performance Test for the release candidate
+# and copies it under the name 'candidate.jar'.
+#
+# Run this script as follows:
+#
+#   ./scripts/build-candidate
+#
+
+set -e
+
+filename="candidate.jar"
+
+if [[ -e "$filename" ]]; then
+    echo "error: $filename: File exists" >&2
+    exit 1
+fi
+
+git checkout -q master
+
+echo "Building '$filename'..."
+
+mvn -q clean package -am -pl tests/perf-test
+cp tests/perf-test/philadelphia-perf-test.jar "$filename"
+
+git checkout -q -


### PR DESCRIPTION
These scripts build Philadelphia Performance Test for the latest release and the release candidate and copy them under the names `baseline.jar` and `candidate.jar`, respectively.