### PR TITLE
philadelphia-core: Fix 'FIXMessageOverflowException' documentation

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageOverflowException.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessageOverflowException.java
@@ -16,7 +16,8 @@
 package com.paritytrading.philadelphia;
 
 /**
- * Indicates that the number of fields exceeds the capacity of a message container.
+ * Indicates that the message length exceeds the capacity of the receive buffer
+ * or that the number of fields exceeds the capacity of a message container.
  */
 public class FIXMessageOverflowException extends FIXException {
 


### PR DESCRIPTION
This exception is thrown both when the message length exceeds the capacity of the receive buffer as well as when the number of fields exceeds the capacity of a message container.