### PR TITLE
philadelphia-core: Make 'FIXValue' into 'CharSequence'

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/Message.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/Message.java
@@ -70,7 +70,7 @@ class Message {
 
         for (int i = 0; i < message.getFieldCount(); i++) {
             int    tag   = message.tagAt(i);
-            String value = message.valueAt(i).asString();
+            String value = message.valueAt(i).toString();
 
             if (tag == MsgType)
                 msgType = value;

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -673,7 +673,7 @@ public class FIXConnection implements Closeable {
                     return;
                 }
 
-                senderCompId = value.asString();
+                senderCompId = value.toString();
             }
 
             if (targetCompId.isEmpty()) {
@@ -683,7 +683,7 @@ public class FIXConnection implements Closeable {
                     return;
                 }
 
-                targetCompId = value.asString();
+                targetCompId = value.toString();
             }
 
             statusListener.logon(FIXConnection.this, message);

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
@@ -317,7 +317,7 @@ public class FIXMessage {
         for (int i = 0; i < count; i++) {
             builder.append(tags[i]);
             builder.append('=');
-            values[i].asString(builder);
+            builder.append(values[i]);
             builder.append('|');
         }
     }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -481,17 +481,6 @@ public class FIXValue implements CharSequence {
     }
 
     /**
-     * Get the value as a string. The value is appended to the provided
-     * string builder.
-     *
-     * @param x a string builder
-     */
-    public void asString(StringBuilder x) {
-        for (int i = 0; i < length; i++)
-            x.append((char)bytes[offset + i]);
-    }
-
-    /**
      * Set the value to a string.
      *
      * @param x a string

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -28,7 +28,7 @@ import org.joda.time.ReadableDateTime;
 /**
  * A value container.
  */
-public class FIXValue {
+public class FIXValue implements CharSequence {
 
     private static final double POWERS_OF_TEN[] = {
         1e0,
@@ -88,10 +88,25 @@ public class FIXValue {
     }
 
     /**
+     * Get the character at the specified index. The index must be between 0
+     * and the length of the value - 1.
+     *
+     * @param index the index
+     * @return the character at the specified index
+     * @throws IndexOutOfBoundsException if the index is outside of this
+     *   value container
+     */
+    @Override
+    public char charAt(int index) {
+        return (char)bytes[offset + index];
+    }
+
+    /**
      * Get the length of the value.
      *
      * @return the length of the value
      */
+    @Override
     public int length() {
         return length;
     }
@@ -697,6 +712,20 @@ public class FIXValue {
      */
     public void put(ByteBuffer buffer) {
         buffer.put(bytes, offset, length + 1);
+    }
+
+    /**
+     * Returns a subsequence of the string representation of this value.
+     *
+     * <p><strong>Note.</strong> This method allocates memory.</p>
+     *
+     * @return a subsequence of the string representation of this value
+     * @throws IndexOutOfBoundsException if either index is outside of this
+     *   value container
+     */
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        return new String(bytes, offset + start, end - start, US_ASCII);
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -18,7 +18,6 @@ package com.paritytrading.philadelphia;
 import static com.paritytrading.philadelphia.FIX.*;
 import static java.nio.charset.StandardCharsets.*;
 
-import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
@@ -479,18 +478,6 @@ public class FIXValue implements CharSequence {
      */
     public CharSequence asString() {
         return this;
-    }
-
-    /**
-     * Get the value as a string. The value is appended to the provided
-     * appendable.
-     *
-     * @param x an appendable
-     * @throws IOException if an I/O error occurs
-     */
-    public void asString(Appendable x) throws IOException {
-        for (int i = 0; i < length; i++)
-            x.append((char)bytes[offset + i]);
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -477,8 +477,8 @@ public class FIXValue implements CharSequence {
      *
      * @return the value as a string
      */
-    public String asString() {
-        return new String(bytes, offset, length, US_ASCII);
+    public CharSequence asString() {
+        return this;
     }
 
     /**
@@ -737,7 +737,7 @@ public class FIXValue implements CharSequence {
      */
     @Override
     public String toString() {
-        return asString();
+        return new String(bytes, offset, length, US_ASCII);
     }
 
     private int getDigits(int digits, int offset) {

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -48,6 +48,20 @@ class FIXValueTest {
     }
 
     @Test
+    void charAt() {
+        value.setInt(123);
+
+        int length = value.length();
+
+        char[] chars = new char[length];
+
+        for (int i = 0; i < length; i++)
+            chars[i] = value.charAt(i);
+
+        assertArrayEquals(new char[] { '1', '2', '3' }, chars);
+    }
+
+    @Test
     void contentEqualsByte() {
         value.setInt(1);
 
@@ -786,6 +800,13 @@ class FIXValueTest {
     @Test
     void getWithOverflow() {
         assertThrows(FIXValueOverflowException.class, () -> value.get(ByteBuffers.wrap("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
+    }
+
+    @Test
+    void subSequence() {
+        value.setInt(123456);
+
+        assertEquals("34", value.subSequence(2, 4));
     }
 
     @Test

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -17,7 +17,6 @@ package com.paritytrading.philadelphia;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import org.joda.time.MutableDateTime;
@@ -634,19 +633,6 @@ class FIXValueTest {
         get("FOO\u0001");
 
         assertTrue("FOO".contentEquals(value.asString()));
-    }
-
-    @Test
-    void asStringWithAppendable() throws IOException {
-        get("FOO\u0001");
-
-        StringBuilder builder = new StringBuilder();
-
-        Appendable appendable = builder;
-
-        value.asString(appendable);
-
-        assertEquals("FOO", builder.toString());
     }
 
     @Test

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -636,17 +636,6 @@ class FIXValueTest {
     }
 
     @Test
-    void asStringWithStringBuilder() {
-        get("FOO\u0001");
-
-        StringBuilder builder = new StringBuilder();
-
-        value.asString(builder);
-
-        assertEquals("FOO", builder.toString());
-    }
-
-    @Test
     void setString() {
         value.setString("FOO");
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -633,7 +633,7 @@ class FIXValueTest {
     void asString() {
         get("FOO\u0001");
 
-        assertEquals("FOO", value.asString());
+        assertTrue("FOO".contentEquals(value.asString()));
     }
 
     @Test

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/TestMessageParser.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/TestMessageParser.java
@@ -57,7 +57,7 @@ class TestMessageParser {
 
             message.append(tag);
             message.append('=');
-            value.asString(message);
+            message.append(value);
             message.append('|');
 
             if (tag == CheckSum) {

--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXValueBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXValueBenchmark.java
@@ -144,7 +144,7 @@ public class FIXValueBenchmark extends FIXBenchmark {
     @Benchmark
     public StringBuilder asString() {
         string.setLength(0);
-        stringValue.asString(string);
+        string.append(stringValue);
 
         return string;
     }


### PR DESCRIPTION
To make it easier to work with `FIXValue` objects, make the class implement the [`CharSequence`](https://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html) interface. Furthermore, change the result type of `FIXValue#asString()` from `String` to `CharSequence` and avoid memory allocation. Finally, remove both `FIXValue#asString(Appendable)` as well as `FIXValue#asString(StringBuilder)` methods as redundant as they can now be replaced by [`Appendable#append(CharSequence)`](https://docs.oracle.com/javase/8/docs/api/java/lang/Appendable.html#append-java.lang.CharSequence-) and [`StringBuilder#append(CharSequence)`](https://docs.oracle.com/javase/8/docs/api/java/lang/StringBuilder.html#append-java.lang.CharSequence-).