### PR TITLE
scripts: Fix 'generate-orchestra' and 'generate-repository' scripts

### DIFF
--- a/scripts/generate-orchestra
+++ b/scripts/generate-orchestra
@@ -39,8 +39,12 @@ generate() {
 
     cat scripts/license-orchestra.java > "$output_path"
 
+    if [[ $input_path != /* ]]; then
+        input_path="../../$input_path"
+    fi
+
     (cd applications/generate; \
-            python -m philadelphia.generate "$command" "../../$config_file" "../../$input_path" \
+            python -m philadelphia.generate "$command" "../../$config_file" "$input_path" \
                     >> "../../$output_path")
 }
 

--- a/scripts/generate-repository
+++ b/scripts/generate-repository
@@ -37,10 +37,14 @@ generate() {
     local input_path=$3
     local output_path=$4
 
+    if [[ $input_path != /* ]]; then
+        input_path="../../$input_path"
+    fi
+
     cat scripts/license-repository.java > "$output_path"
 
     (cd applications/generate; \
-            python -m philadelphia.generate "$command" "../../$config_path" "../../$input_path" >> "../../$output_path")
+            python -m philadelphia.generate "$command" "../../$config_path" "$input_path" >> "../../$output_path")
 }
 
 generate_version() {


### PR DESCRIPTION
Make them work either with an absolute path or a relative path to the input file or the input directory, respectively.