### PR TITLE
philadelphia-generate: Remove Pylint configuration

### DIFF
--- a/applications/generate/.pylintrc
+++ b/applications/generate/.pylintrc
@@ -1,2 +1,0 @@
-[MESSAGES CONTROL]
-disable=missing-docstring,too-few-public-methods


### PR DESCRIPTION
It is no longer used.