### PR TITLE
philadelphia-core: Clean up 'FIXValue#setTimeOnly()' and 'FIXValue#setTimestamp()'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -155,7 +155,7 @@ public class FIXConnection implements Closeable {
 
         this.currentTimestamp = new FIXValue(CURRENT_TIMESTAMP_FIELD_CAPACITY);
 
-        this.currentTimestamp.setTimestamp(this.currentTime, true);
+        this.currentTimestamp.setTimestampMillis(this.currentTime);
     }
 
     /**
@@ -317,7 +317,7 @@ public class FIXConnection implements Closeable {
 
         currentTime.setMillis(currentTimeMillis);
 
-        currentTimestamp.setTimestamp(currentTime, true);
+        currentTimestamp.setTimestampMillis(currentTime);
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -614,12 +614,11 @@ public class FIXValue implements CharSequence {
     }
 
     /**
-     * Set the value to a timestamp.
+     * Set the value to a timestamp with the granularity of milliseconds.
      *
      * @param x a timestamp
-     * @param millis if true set milliseconds, otherwise do not set milliseconds
      */
-    public void setTimestamp(ReadableDateTime x, boolean millis) {
+    public void setTimestampMillis(ReadableDateTime x) {
         setDigits(x.getYear(), 0, 4);
         setDigits(x.getMonthOfYear(), 4, 2);
         setDigits(x.getDayOfMonth(), 6, 2);
@@ -629,20 +628,33 @@ public class FIXValue implements CharSequence {
         setDigits(x.getMinuteOfHour(), 12, 2);
         bytes[14] = ':';
         setDigits(x.getSecondOfMinute(), 15, 2);
-
-        if (millis) {
-            bytes[17] = '.';
-            setDigits(x.getMillisOfSecond(), 18, 3);
-            bytes[21] = SOH;
-
-            length = 21;
-        } else {
-            bytes[17] = SOH;
-
-            length = 17;
-        }
+        bytes[17] = '.';
+        setDigits(x.getMillisOfSecond(), 18, 3);
+        bytes[21] = SOH;
 
         offset = 0;
+        length = 21;
+    }
+
+    /**
+     * Set the value to a timestamp with the granularity of seconds.
+     *
+     * @param x a timestamp
+     */
+    public void setTimestampSecs(ReadableDateTime x) {
+        setDigits(x.getYear(), 0, 4);
+        setDigits(x.getMonthOfYear(), 4, 2);
+        setDigits(x.getDayOfMonth(), 6, 2);
+        bytes[8] = '-';
+        setDigits(x.getHourOfDay(), 9, 2);
+        bytes[11] = ':';
+        setDigits(x.getMinuteOfHour(), 12, 2);
+        bytes[14] = ':';
+        setDigits(x.getSecondOfMinute(), 15, 2);
+        bytes[17] = SOH;
+
+        offset = 0;
+        length = 17;
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -556,31 +556,39 @@ public class FIXValue implements CharSequence {
     }
 
     /**
-     * Set the value to a time only.
+     * Set the value to a time only with the granularity of milliseconds.
      *
      * @param x a time only
-     * @param millis if true set milliseconds, otherwise do not set milliseconds
      */
-    public void setTimeOnly(ReadableDateTime x, boolean millis) {
+    public void setTimeOnlyMillis(ReadableDateTime x) {
         setDigits(x.getHourOfDay(), 0, 2);
         bytes[2] = ':';
         setDigits(x.getMinuteOfHour(), 3, 2);
         bytes[5] = ':';
         setDigits(x.getSecondOfMinute(), 6, 2);
-
-        if (millis) {
-            bytes[8] = '.';
-            setDigits(x.getMillisOfSecond(), 9, 3);
-            bytes[12] = SOH;
-
-            length = 12;
-        } else {
-            bytes[8] = SOH;
-
-            length = 8;
-        }
+        bytes[8] = '.';
+        setDigits(x.getMillisOfSecond(), 9, 3);
+        bytes[12] = SOH;
 
         offset = 0;
+        length = 12;
+    }
+
+    /**
+     * Set the value to a time only with the granularity of seconds.
+     *
+     * @param x a time only
+     */
+    public void setTimeOnlySecs(ReadableDateTime x) {
+        setDigits(x.getHourOfDay(), 0, 2);
+        bytes[2] = ':';
+        setDigits(x.getMinuteOfHour(), 3, 2);
+        bytes[5] = ':';
+        setDigits(x.getSecondOfMinute(), 6, 2);
+        bytes[8] = SOH;
+
+        offset = 0;
+        length = 8;
     }
 
     /**

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXMessageTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXMessageTest.java
@@ -41,7 +41,7 @@ class FIXMessageTest {
         message.addField(HandlInst).setChar(HandlInstValues.AutomatedExecutionNoIntervention);
         message.addField(Symbol).setString("FOO");
         message.addField(Side).setChar(SideValues.Buy);
-        message.addField(TransactTime).setTimestamp(timestamp, true);
+        message.addField(TransactTime).setTimestampMillis(timestamp);
         message.addField(OrderQty).setInt(100);
         message.addField(OrdType).setChar(OrdTypeValues.Limit);
         message.addField(Price).setFloat(150.25, 2);
@@ -74,7 +74,7 @@ class FIXMessageTest {
         message.addField(HandlInst).setChar(HandlInstValues.AutomatedExecutionNoIntervention);
         message.addField(Symbol).setString("FOO");
         message.addField(Side).setChar(SideValues.Buy);
-        message.addField(TransactTime).setTimestamp(timestamp, true);
+        message.addField(TransactTime).setTimestampMillis(timestamp);
         message.addField(OrderQty).setInt(100);
         message.addField(OrdType).setChar(OrdTypeValues.Limit);
         message.addField(Price).setFloat(150.25, 2);

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -697,15 +697,15 @@ class FIXValueTest {
     }
 
     @Test
-    void setTimeOnlyWithMillis() {
-        value.setTimeOnly(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), true);
+    void setTimeOnlyMillis() {
+        value.setTimeOnlyMillis(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
 
         assertEquals("09:30:05.250\u0001", put());
     }
 
     @Test
-    void setTimeOnlyWithoutMillis() {
-        value.setTimeOnly(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), false);
+    void setTimeOnlySecs() {
+        value.setTimeOnlySecs(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
 
         assertEquals("09:30:05\u0001", put());
     }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -740,15 +740,15 @@ class FIXValueTest {
     }
 
     @Test
-    void setTimestampWithMillis() {
-        value.setTimestamp(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), true);
+    void setTimestampMillis() {
+        value.setTimestampMillis(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
 
         assertEquals("20150924-09:30:05.250\u0001", put());
     }
 
     @Test
-    void setTimestampWithoutMillis() {
-        value.setTimestamp(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), false);
+    void setTimestampSecs() {
+        value.setTimestampSecs(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
 
         assertEquals("20150924-09:30:05\u0001", put());
     }

--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXValueBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXValueBenchmark.java
@@ -82,7 +82,7 @@ public class FIXValueBenchmark extends FIXBenchmark {
         timeOnlyValue.setTimeOnlyMillis(timeOnly);
 
         timestampValue = new FIXValue(64);
-        timestampValue.setTimestamp(timestamp, true);
+        timestampValue.setTimestampMillis(timestamp);
 
         copyValue = new FIXValue(64);
     }
@@ -187,7 +187,7 @@ public class FIXValueBenchmark extends FIXBenchmark {
 
     @Benchmark
     public void setTimestamp() {
-        timestampValue.setTimestamp(timestamp, true);
+        timestampValue.setTimestampMillis(timestamp);
     }
 
     @Benchmark

--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXValueBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXValueBenchmark.java
@@ -79,7 +79,7 @@ public class FIXValueBenchmark extends FIXBenchmark {
         dateValue.setDate(date);
 
         timeOnlyValue = new FIXValue(64);
-        timeOnlyValue.setTimeOnly(timeOnly, true);
+        timeOnlyValue.setTimeOnlyMillis(timeOnly);
 
         timestampValue = new FIXValue(64);
         timestampValue.setTimestamp(timestamp, true);
@@ -175,7 +175,7 @@ public class FIXValueBenchmark extends FIXBenchmark {
 
     @Benchmark
     public void setTimeOnly() {
-        timeOnlyValue.setTimeOnly(timeOnly, true);
+        timeOnlyValue.setTimeOnlySecs(timeOnly);
     }
 
     @Benchmark


### PR DESCRIPTION
Split `FIXValue#setTimeOnly()` into two methods:
- `FIXValue#setTimeOnlyMillis()`
- `FIXValue#setTimeOnlySecs()`

Split `FIXValue#setTimestamp()` into two methods:
- `FIXValue#setTimestampMillis()`
- `FIXValue#setTimestampSecs()`