### PR TITLE
philadelphia-core: Improve 'FIXMessage#valueOf()'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -34,6 +34,8 @@ public class FIXConnection implements Closeable {
 
     private static final int CURRENT_TIMESTAMP_FIELD_CAPACITY = 24;
 
+    private static final FIXValue FALSE = FIXValue.fromBoolean(false);
+
     private final SocketChannel channel;
 
     private final FIXConfig config;
@@ -592,9 +594,9 @@ public class FIXConnection implements Closeable {
 
         private void handleTooLowMsgSeqNum(FIXMessage message, FIXValue msgType, long msgSeqNum) throws IOException {
             if (!msgType.contentEquals(SequenceReset)) {
-                FIXValue possDupFlag = message.valueOf(PossDupFlag);
+                FIXValue possDupFlag = message.valueOf(PossDupFlag, FALSE);
 
-                if (possDupFlag == null || possDupFlag.asBoolean() == false)
+                if (possDupFlag.asBoolean() == false)
                     statusListener.tooLowMsgSeqNum(FIXConnection.this, msgSeqNum, rxMsgSeqNum);
             }
         }
@@ -657,8 +659,8 @@ public class FIXConnection implements Closeable {
 
             rxMsgSeqNum = newSeqNo;
 
-            FIXValue gapFillFlag = message.valueOf(GapFillFlag);
-            boolean reset = gapFillFlag == null || gapFillFlag.asBoolean() == false;
+            FIXValue gapFillFlag = message.valueOf(GapFillFlag, FALSE);
+            boolean reset = gapFillFlag.asBoolean() == false;
 
             if (reset)
                 statusListener.sequenceReset(FIXConnection.this);

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXMessage.java
@@ -140,6 +140,24 @@ public class FIXMessage {
 
     /**
      * Get the value container of the first instance of a field with the
+     * specified tag or the default value container.
+     *
+     * @param tag the tag
+     * @param defaultValue the default value container
+     * @return the value container or the default value container if there are
+     *   no instances of a field with the specified tag
+     */
+    public FIXValue valueOf(int tag, FIXValue defaultValue) {
+        for (int i = 0; i < count; i++) {
+            if (tags[i] == tag)
+                return values[i];
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Get the value container of the first instance of a field with the
      * specified tag, starting at the specified index.
      *
      * @param tag the tag
@@ -154,6 +172,26 @@ public class FIXMessage {
         }
 
         return null;
+    }
+
+    /**
+     * Get the value container of the first instance of a field with the
+     * specified tag, starting at the specified index, or the default value
+     * container.
+     *
+     * @param tag the tag
+     * @param fromIndex the index to start the search from
+     * @param defaultValue the default value container
+     * @return the value container or the default value container if there are
+     *   no instances of a field with the specified tag
+     */
+    public FIXValue valueOf(int tag, int fromIndex, FIXValue defaultValue) {
+        for (int i = 0; i < count; i++) {
+            if (tags[i] == tag)
+                return values[i];
+        }
+
+        return defaultValue;
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -608,6 +608,20 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a date.
+     *
+     * @param x a date
+     * @return a value container
+     */
+    public static FIXValue fromDate(ReadableDateTime x) {
+        FIXValue value = new FIXValue(9);
+
+        value.setDate(x);
+
+        return value;
+    }
+
+    /**
      * Get the value as a time only.
      *
      * @param x a time only

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -660,6 +660,21 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a time only with the granularity of
+     * milliseconds.
+     *
+     * @param x a time only
+     * @return a value container
+     */
+    public static FIXValue fromTimeOnlyMillis(ReadableDateTime x) {
+        FIXValue value = new FIXValue(13);
+
+        value.setTimeOnlyMillis(x);
+
+        return value;
+    }
+
+    /**
      * Set the value to a time only with the granularity of seconds.
      *
      * @param x a time only

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -788,6 +788,21 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a timestamp with the granularity of
+     * seconds.
+     *
+     * @param x a timestamp
+     * @return a value container
+     */
+    public static FIXValue fromTimestampSecs(ReadableDateTime x) {
+        FIXValue value = new FIXValue(18);
+
+        value.setTimestampSecs(x);
+
+        return value;
+    }
+
+    /**
      * Set the value to a checksum.
      *
      * @param x a checksum

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -275,6 +275,20 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a character.
+     *
+     * @param x a character
+     * @return a value container
+     */
+    public static FIXValue fromChar(char x) {
+        FIXValue value = new FIXValue(2);
+
+        value.setChar(x);
+
+        return value;
+    }
+
+    /**
      * Get the value as an integer.
      *
      * @return the value as an integer

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -692,6 +692,21 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a time only with the granularity of
+     * seconds.
+     *
+     * @param x a time only
+     * @return a value container
+     */
+    public static FIXValue fromTimeOnlySecs(ReadableDateTime x) {
+        FIXValue value = new FIXValue(9);
+
+        value.setTimeOnlySecs(x);
+
+        return value;
+    }
+
+    /**
      * Get the value as a timestamp.
      *
      * @param x a timestamp

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -752,6 +752,21 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a timestamp with the granularity of
+     * milliseconds.
+     *
+     * @param x a timestamp
+     * @return a value container
+     */
+    public static FIXValue fromTimestampMillis(ReadableDateTime x) {
+        FIXValue value = new FIXValue(22);
+
+        value.setTimestampMillis(x);
+
+        return value;
+    }
+
+    /**
      * Set the value to a timestamp with the granularity of seconds.
      *
      * @param x a timestamp

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -362,6 +362,20 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from an integer.
+     *
+     * @param x an integer
+     * @return a value container
+     */
+    public static FIXValue fromInt(long x) {
+        FIXValue value = new FIXValue(21);
+
+        value.setInt(x);
+
+        return value;
+    }
+
+    /**
      * Get the value as a float.
      *
      * <p><strong>Note.</strong> The value is a string representation of

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -554,6 +554,20 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a string.
+     *
+     * @param x a string
+     * @return a value container
+     */
+    public static FIXValue fromString(CharSequence x) {
+        FIXValue value = new FIXValue(x.length() + 1);
+
+        value.setString(x);
+
+        return value;
+    }
+
+    /**
      * Get the value as a date.
      *
      * <p><strong>Note.</strong> This method sets both date and time fields.

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -514,6 +514,21 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a float.
+     *
+     * @param x a float
+     * @param decimals the number of decimals
+     * @return a value container
+     */
+    public static FIXValue fromFloat(double x, int decimals) {
+        FIXValue value = new FIXValue(22);
+
+        value.setFloat(x, decimals);
+
+        return value;
+    }
+
+    /**
      * Get the value as a string.
      *
      * @return the value as a string

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -235,6 +235,20 @@ public class FIXValue implements CharSequence {
     }
 
     /**
+     * Construct a value container from a boolean.
+     *
+     * @param x a boolean
+     * @return a value container
+     */
+    public static FIXValue fromBoolean(boolean x) {
+        FIXValue value = new FIXValue(2);
+
+        value.setBoolean(x);
+
+        return value;
+    }
+
+    /**
      * Get the value as a character.
      *
      * @return the value as a character

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -738,6 +738,17 @@ class FIXValueTest {
     }
 
     @Test
+    void fromDate() {
+        FIXValue constant = FIXValue.fromDate(new MutableDateTime(2015, 9, 24, 0, 0, 0, 0));
+
+        MutableDateTime d = new MutableDateTime(1970, 1, 1, 9, 30, 5, 250);
+
+        constant.asDate(d);
+
+        assertEquals(new MutableDateTime(2015, 9, 24, 0, 0, 0, 0), d);
+    }
+
+    @Test
     void asTimeOnlyWithMillis() {
         get("09:30:05.250\u0001");
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -335,6 +335,20 @@ class FIXValueTest {
     }
 
     @Test
+    void fromIntMinValue() {
+        FIXValue constant = FIXValue.fromInt(Long.MIN_VALUE);
+
+        assertEquals(Long.MIN_VALUE, constant.asInt());
+    }
+
+    @Test
+    void fromIntMaxValue() {
+        FIXValue constant = FIXValue.fromInt(Long.MAX_VALUE);
+
+        assertEquals(Long.MAX_VALUE, constant.asInt());
+    }
+
+    @Test
     void asFloatMinValue() {
         get("-900719925474099100.0");
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -664,6 +664,34 @@ class FIXValueTest {
     }
 
     @Test
+    void fromFloatMinValue() {
+        FIXValue constant = FIXValue.fromFloat(-900719925474099100.0, 0);
+
+        assertEquals(-900719925474099100.0, constant.asFloat());
+    }
+
+    @Test
+    void fromFloatMinusMinDecimal() {
+        FIXValue constant = FIXValue.fromFloat(-0.00000000000000001, 17);
+
+        assertEquals(-0.00000000000000001, constant.asFloat());
+    }
+
+    @Test
+    void fromFloatMinDecimal() {
+        FIXValue constant = FIXValue.fromFloat(0.00000000000000001, 17);
+
+        assertEquals(0.00000000000000001, constant.asFloat());
+    }
+
+    @Test
+    void fromFloatMaxValue() {
+        FIXValue constant = FIXValue.fromFloat(900719925474099100.0, 0);
+
+        assertEquals(900719925474099100.0, constant.asFloat());
+    }
+
+    @Test
     void asString() {
         get("FOO\u0001");
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -216,6 +216,13 @@ class FIXValueTest {
     }
 
     @Test
+    void fromChar() {
+        FIXValue constant = FIXValue.fromChar('Y');
+
+        assertEquals('Y', constant.asChar());
+    }
+
+    @Test
     void asIntMinValue() {
         get("-9223372036854775808\u0001");
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -785,6 +785,17 @@ class FIXValueTest {
     }
 
     @Test
+    void fromTimeOnlyMillis() {
+        FIXValue constant = FIXValue.fromTimeOnlyMillis(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
+
+        MutableDateTime t = new MutableDateTime(2015, 9, 24, 22, 45, 10, 750);
+
+        constant.asTimeOnly(t);
+
+        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), t);
+    }
+
+    @Test
     void setTimeOnlySecs() {
         value.setTimeOnlySecs(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -868,6 +868,17 @@ class FIXValueTest {
     }
 
     @Test
+    void fromTimestampSecs() {
+        FIXValue constant = FIXValue.fromTimestampSecs(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
+
+        MutableDateTime t = new MutableDateTime();
+
+        constant.asTimestamp(t);
+
+        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 0), t);
+    }
+
+    @Test
     void setCheckSum() {
         value.setCheckSum(320);
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -181,6 +181,20 @@ class FIXValueTest {
     }
 
     @Test
+    void fromBooleanTrue() {
+        FIXValue constant = FIXValue.fromBoolean(true);
+
+        assertTrue(constant.asBoolean());
+    }
+
+    @Test
+    void fromBooleanFalse() {
+        FIXValue constant = FIXValue.fromBoolean(false);
+
+        assertFalse(constant.asBoolean());
+    }
+
+    @Test
     void asChar() {
         get("Y\u0001");
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -706,6 +706,13 @@ class FIXValueTest {
     }
 
     @Test
+    void fromString() {
+        FIXValue constant = FIXValue.fromString("FOO");
+
+        assertTrue("FOO".contentEquals(constant.asString()));
+    }
+
+    @Test
     void asDate() {
         get("20150924\u0001");
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -850,6 +850,17 @@ class FIXValueTest {
     }
 
     @Test
+    void fromTimestampMillis() {
+        FIXValue constant = FIXValue.fromTimestampMillis(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
+
+        MutableDateTime t = new MutableDateTime();
+
+        constant.asTimestamp(t);
+
+        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), t);
+    }
+
+    @Test
     void setTimestampSecs() {
         value.setTimestampSecs(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -803,6 +803,17 @@ class FIXValueTest {
     }
 
     @Test
+    void fromTimeOnlySecs() {
+        FIXValue constant = FIXValue.fromTimeOnlySecs(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
+
+        MutableDateTime t = new MutableDateTime(2015, 9, 24, 22, 45, 10, 750);
+
+        constant.asTimeOnly(t);
+
+        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 0), t);
+    }
+
+    @Test
     void asTimestampWithMillis() {
         get("20150924-09:30:05.250\u0001");
 


### PR DESCRIPTION
Make it possible to pass the method a default value container. If the specified tag is not found, the method returns the default value container.