### PR TITLE
philadelphia-generate: Fix QuickFIX support

### DIFF
--- a/applications/generate/philadelphia/quickfix.py
+++ b/applications/generate/philadelphia/quickfix.py
@@ -39,10 +39,10 @@ def read_enumerations(filename: str) -> typing.List[model.Enumeration]:
     def enumeration(elem: etree.Element) -> model.Enumeration:
         field = _read_field(elem)
         type_ = _read_type(elem)
-        values = _read_values(elem) if _has_values(field.name) else []
+        values = _read_values(elem)
         return model.Enumeration(primary_field=field, secondary_fields=[], type_=type_, values=values)
     tree = etree.parse(filename)
-    return sorted([enumeration(elem) for elem in tree.findall('./fields/field')],
+    return sorted([enumeration(elem) for elem in tree.findall('./fields/field') if _has_values(elem)],
                   key=lambda enumeration: int(enumeration.primary_field.tag))
 
 
@@ -70,8 +70,8 @@ def _read_type(elem: etree.Element) -> str:
     return _TYPES.get(type_, 'String')
 
 
-def _has_values(name: str) -> bool:
-    return name != 'MsgType'
+def _has_values(elem: etree.Element) -> bool:
+    return etree.get(elem, 'name') != 'MsgType' and elem.find('value') is not None
 
 
 def _read_values(root: etree.Element) -> typing.List[model.Value]:


### PR DESCRIPTION
Do not try to generate enumerations based on `field` elements that do not contain any `value` elements.

In addition, as with the FIX Repository, update the enumeration type from `char` to `String` if any of the enumeration values has a length greater than one.