### PR TITLE
Logout on wrong sequence number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.jar
 target/
+.idea/

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -548,6 +548,12 @@ public class FIXConnection implements Closeable {
             }
 
             if (msgSeqNum != rxMsgSeqNum) {
+                // Sometimes a logout request can be paired with the 'MsgSeqNum too low' error
+                // which doesn't allow to proceed with a Resend sequence
+                if (msgType.byteAt(0) == Logout) {
+                    handleLogout(message);
+                    return;
+                }
                 handleMsgSeqNum(message, msgType, msgSeqNum);
                 return;
             }


### PR DESCRIPTION
I've encountered cases where the FIX 5.0 SP1 server will immediately logout and terminate connection upon receiving a wrong sequence number. Does the change make sense?