### PR TITLE
philadelphia-core: Add 'FIXTimestamp'

### DIFF
--- a/applications/client/pom.xml
+++ b/applications/client/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>config</artifactId>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jline-reader</artifactId>
     </dependency>

--- a/examples/acceptor/pom.xml
+++ b/examples/acceptor/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>philadelphia-fix42</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/examples/initiator/pom.xml
+++ b/examples/initiator/pom.xml
@@ -40,10 +40,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
     </dependency>

--- a/libraries/core/README.md
+++ b/libraries/core/README.md
@@ -2,23 +2,6 @@
 
 Philadelphia Core implements the Financial Information Exchange (FIX) protocol.
 
-## Dependencies
-
-Philadelphia Core depends on the following libraries:
-
-- Joda-Time 2.x
-
-If you do not already use Joda-Time 2.x in your application, add a Maven
-dependency to it. For example:
-
-```xml
-<dependency>
-  <groupId>joda-time</groupId>
-  <artifactId>joda-time</artifactId>
-  <version>2.10.10</version>
-</dependency>
-```
-
 ## Download
 
 Add a Maven dependency to Philadelphia Core:

--- a/libraries/core/pom.xml
+++ b/libraries/core/pom.xml
@@ -36,11 +36,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -24,8 +24,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
-import org.joda.time.DateTimeZone;
-import org.joda.time.MutableDateTime;
 
 /**
  * A connection.
@@ -85,7 +83,7 @@ public class FIXConnection implements Closeable {
 
     private long currentTimeMillis;
 
-    private final MutableDateTime currentTime;
+    private final FIXTimestamp currentTime;
 
     private final FIXValue currentTimestamp;
 
@@ -147,7 +145,7 @@ public class FIXConnection implements Closeable {
 
         this.currentTimeMillis = 0;
 
-        this.currentTime = new MutableDateTime(this.currentTimeMillis, DateTimeZone.UTC);
+        this.currentTime = new FIXTimestamp();
 
         this.currentTimestamp = new FIXValue(CURRENT_TIMESTAMP_FIELD_CAPACITY);
 
@@ -321,7 +319,7 @@ public class FIXConnection implements Closeable {
     public void setCurrentTimeMillis(long currentTimeMillis) {
         this.currentTimeMillis = currentTimeMillis;
 
-        currentTime.setMillis(currentTimeMillis);
+        currentTime.setEpochMilli(currentTimeMillis);
 
         currentTimestamp.setTimestampMillis(currentTime);
     }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamp.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXTimestamp.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2022 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+import static java.util.Calendar.*;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * A timestamp container.
+ */
+public class FIXTimestamp {
+
+    private final Calendar calendar;
+
+    private int year;
+    private int month;
+    private int day;
+    private int hour;
+    private int minute;
+    private int second;
+    private int milli;
+
+    /**
+     * Construct a new instance representing the epoch of
+     * 1970-01-01T00:00:00.000Z.
+     */
+    public FIXTimestamp() {
+        this(1970, 1, 1, 0, 0, 0, 0);
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param year the year
+     * @param month the month, from 1 to 12
+     * @param day the day, from 1 to 31
+     * @param hour the hour, from 0 to 23
+     * @param minute the minute, from 0 to 59
+     * @param second the second, from 0 to 59
+     * @param milli the millisecond, from 0 to 999
+     */
+    public FIXTimestamp(int year, int month, int day, int hour, int minute, int second, int milli) {
+        this.calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+
+        this.year = year;
+        this.month = month;
+        this.day = day;
+        this.hour = hour;
+        this.minute = minute;
+        this.second = second;
+        this.milli = milli;
+    }
+
+    /**
+     * Get the year.
+     *
+     * @return the year
+     */
+    public int getYear() {
+        return year;
+    }
+
+    /**
+     * Set the year.
+     *
+     * @param year the year
+     */
+    public void setYear(int year) {
+        this.year = year;
+    }
+
+    /**
+     * Get the month, from 1 to 12.
+     *
+     * @return the month
+     */
+    public int getMonth() {
+        return month;
+    }
+
+    /**
+     * Set the month, from 1 to 12.
+     *
+     * @param month the month
+     */
+    public void setMonth(int month) {
+        this.month = month;
+    }
+
+    /**
+     * Get the day, from 1 to 31.
+     *
+     * @return the day
+     */
+    public int getDay() {
+        return day;
+    }
+
+    /**
+     * Set the day, from 1 to 31.
+     *
+     * @param day the day
+     */
+    public void setDay(int day) {
+        this.day = day;
+    }
+
+    /**
+     * Get the hour, from 0 to 23.
+     *
+     * @return the hour
+     */
+    public int getHour() {
+        return hour;
+    }
+
+    /**
+     * Set the hour, from 0 to 23.
+     *
+     * @param hour the hour
+     */
+    public void setHour(int hour) {
+        this.hour = hour;
+    }
+
+    /**
+     * Get the minute, from 0 to 59.
+     *
+     * @return the minute
+     */
+    public int getMinute() {
+        return minute;
+    }
+
+    /**
+     * Set the minute, from 0 to 59.
+     *
+     * @param minute the minute
+     */
+    public void setMinute(int minute) {
+        this.minute = minute;
+    }
+
+    /**
+     * Get the second, from 0 to 59.
+     *
+     * @return the second
+     */
+    public int getSecond() {
+        return second;
+    }
+
+    /**
+     * Set the second, from 0 to 59.
+     *
+     * @param second the second
+     */
+    public void setSecond(int second) {
+        this.second = second;
+    }
+
+    /**
+     * Get the millisecond, from 0 to 999.
+     *
+     * @return the millisecond
+     */
+    public int getMilli() {
+        return milli;
+    }
+
+    /**
+     * Set the millisecond, from 0 to 999.
+     *
+     * @param milli the millisecond
+     */
+    public void setMilli(int milli) {
+        this.milli = milli;
+    }
+
+    /**
+     * Get the number of milliseconds from the epoch of 1970-01-01T00:00:00.000Z.
+     *
+     * @return the number of milliseconds from the epoch
+     */
+    public long getEpochMilli() {
+        calendar.set(MILLISECOND, milli);
+        calendar.set(year, month - 1, day, hour, minute, second);
+
+        return calendar.getTimeInMillis();
+    }
+
+    /**
+     * Set the number of milliseconds from the epoch of 1970-01-01T00:00:00.000Z.
+     *
+     * @param epochMilli the number of milliseconds from the epoch
+     */
+    public void setEpochMilli(long epochMilli) {
+        calendar.setTimeInMillis(epochMilli);
+
+        year = calendar.get(YEAR);
+        month = calendar.get(MONTH) + 1;
+        day = calendar.get(DAY_OF_MONTH);
+        hour = calendar.get(HOUR_OF_DAY);
+        minute = calendar.get(MINUTE);
+        second = calendar.get(SECOND);
+        milli = calendar.get(MILLISECOND);
+    }
+
+    /**
+     * Returns true if the specified object is equal to this instance,
+     * otherwise false.
+     *
+     * @return true if the specified object is equal to this instance,
+     *     otherwise false
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this)
+            return true;
+
+        if (!(obj instanceof FIXTimestamp))
+            return false;
+
+        FIXTimestamp timestamp = (FIXTimestamp)obj;
+
+        if (timestamp.year != year)
+            return false;
+
+        if (timestamp.month != month)
+            return false;
+
+        if (timestamp.day != day)
+            return false;
+
+        if (timestamp.hour != hour)
+            return false;
+
+        if (timestamp.minute != minute)
+            return false;
+
+        if (timestamp.second != second)
+            return false;
+
+        if (timestamp.milli != milli)
+            return false;
+
+        return true;
+    }
+
+    /**
+     * Returns the hash code value for this instance.
+     *
+     * @return the hash code value for this instance
+     */
+    @Override
+    public int hashCode() {
+        return (year + (month << 16) + (day << 24))
+            ^ (hour + (minute << 8) + (second << 16) + (milli << 24));
+    }
+
+    /**
+     * Returns a string representation of this value.
+     *
+     * <p><strong>Note.</strong> This method allocates memory.</p>
+     *
+     * @return a string representation of this value
+     */
+    @Override
+    public String toString() {
+        return String.format("%04d%02d%02d-%02d:%02d:%02d.%03d",
+                year, month, day, hour, minute, second, milli);
+    }
+
+}

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -21,8 +21,6 @@ import static java.nio.charset.StandardCharsets.*;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
-import org.joda.time.MutableDateTime;
-import org.joda.time.ReadableDateTime;
 
 /**
  * A value container.
@@ -499,26 +497,16 @@ public class FIXValue implements CharSequence {
     /**
      * Get the value as a date.
      *
-     * <p><strong>Note.</strong> This method sets both date and time fields.
-     * When combining this method and {@link #asTimeOnly(MutableDateTime)},
-     * this method should be invoked first.</p>
-     *
      * @param x a date
      * @throws FIXValueFormatException if the value is not a date
-     * @see #asTimeOnly(MutableDateTime)
      */
-    public void asDate(MutableDateTime x) {
+    public void asDate(FIXTimestamp x) {
         if (length != 8)
             notDate();
 
-        int year        = getDigits(4, offset + 0);
-        int monthOfYear = getDigits(2, offset + 4);
-        int dayOfMonth  = getDigits(2, offset + 6);
-
-        // Note: 'setDateTime()' takes roughly 55% of the time 'setDate()'
-        // takes. Using individual methods, such as 'setYear()', is faster
-        // than using 'setDate()' but still slower than 'setDateTime()'.
-        x.setDateTime(year, monthOfYear, dayOfMonth, 0, 0, 0, 0);
+        x.setYear(getDigits(4, offset + 0));
+        x.setMonth(getDigits(2, offset + 4));
+        x.setDay(getDigits(2, offset + 6));
     }
 
     /**
@@ -526,10 +514,10 @@ public class FIXValue implements CharSequence {
      *
      * @param x a date
      */
-    public void setDate(ReadableDateTime x) {
+    public void setDate(FIXTimestamp x) {
         setDigits(x.getYear(), 0, 4);
-        setDigits(x.getMonthOfYear(), 4, 2);
-        setDigits(x.getDayOfMonth(), 6, 2);
+        setDigits(x.getMonth(), 4, 2);
+        setDigits(x.getDay(), 6, 2);
         bytes[8] = SOH;
 
         length = 8;
@@ -541,18 +529,15 @@ public class FIXValue implements CharSequence {
      *
      * @param x a time only
      * @throws FIXValueFormatException if the value is not a time only
-     * @see #asDate(MutableDateTime)
      */
-    public void asTimeOnly(MutableDateTime x) {
+    public void asTimeOnly(FIXTimestamp x) {
         if (length != 8 && length != 12)
             notTimeOnly();
 
-        int hourOfDay      = getDigits(2, offset + 0);
-        int minuteOfHour   = getDigits(2, offset + 3);
-        int secondOfMinute = getDigits(2, offset + 6);
-        int millisOfSecond = length == 12 ? getDigits(3, offset + 9) : 0;
-
-        x.setTime(hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond);
+        x.setHour(getDigits(2, offset + 0));
+        x.setMinute(getDigits(2, offset + 3));
+        x.setSecond(getDigits(2, offset + 6));
+        x.setMilli(length == 12 ? getDigits(3, offset + 9) : 0);
     }
 
     /**
@@ -560,14 +545,14 @@ public class FIXValue implements CharSequence {
      *
      * @param x a time only
      */
-    public void setTimeOnlyMillis(ReadableDateTime x) {
-        setDigits(x.getHourOfDay(), 0, 2);
+    public void setTimeOnlyMillis(FIXTimestamp x) {
+        setDigits(x.getHour(), 0, 2);
         bytes[2] = ':';
-        setDigits(x.getMinuteOfHour(), 3, 2);
+        setDigits(x.getMinute(), 3, 2);
         bytes[5] = ':';
-        setDigits(x.getSecondOfMinute(), 6, 2);
+        setDigits(x.getSecond(), 6, 2);
         bytes[8] = '.';
-        setDigits(x.getMillisOfSecond(), 9, 3);
+        setDigits(x.getMilli(), 9, 3);
         bytes[12] = SOH;
 
         offset = 0;
@@ -579,12 +564,12 @@ public class FIXValue implements CharSequence {
      *
      * @param x a time only
      */
-    public void setTimeOnlySecs(ReadableDateTime x) {
-        setDigits(x.getHourOfDay(), 0, 2);
+    public void setTimeOnlySecs(FIXTimestamp x) {
+        setDigits(x.getHour(), 0, 2);
         bytes[2] = ':';
-        setDigits(x.getMinuteOfHour(), 3, 2);
+        setDigits(x.getMinute(), 3, 2);
         bytes[5] = ':';
-        setDigits(x.getSecondOfMinute(), 6, 2);
+        setDigits(x.getSecond(), 6, 2);
         bytes[8] = SOH;
 
         offset = 0;
@@ -597,20 +582,17 @@ public class FIXValue implements CharSequence {
      * @param x a timestamp
      * @throws FIXValueFormatException if the value is not a timestamp
      */
-    public void asTimestamp(MutableDateTime x) {
+    public void asTimestamp(FIXTimestamp x) {
         if (length != 17 && length != 21)
             notTimestamp();
 
-        int year           = getDigits(4, offset + 0);
-        int monthOfYear    = getDigits(2, offset + 4);
-        int dayOfMonth     = getDigits(2, offset + 6);
-        int hourOfDay      = getDigits(2, offset + 9);
-        int minuteOfHour   = getDigits(2, offset + 12);
-        int secondOfMinute = getDigits(2, offset + 15);
-        int millisOfSecond = length == 21 ? getDigits(3, offset + 18) : 0;
-
-        x.setDateTime(year, monthOfYear, dayOfMonth, hourOfDay, minuteOfHour,
-                secondOfMinute, millisOfSecond);
+        x.setYear(getDigits(4, offset + 0));
+        x.setMonth(getDigits(2, offset + 4));
+        x.setDay(getDigits(2, offset + 6));
+        x.setHour(getDigits(2, offset + 9));
+        x.setMinute(getDigits(2, offset + 12));
+        x.setSecond(getDigits(2, offset + 15));
+        x.setMilli(length == 21 ? getDigits(3, offset + 18) : 0);
     }
 
     /**
@@ -618,18 +600,18 @@ public class FIXValue implements CharSequence {
      *
      * @param x a timestamp
      */
-    public void setTimestampMillis(ReadableDateTime x) {
+    public void setTimestampMillis(FIXTimestamp x) {
         setDigits(x.getYear(), 0, 4);
-        setDigits(x.getMonthOfYear(), 4, 2);
-        setDigits(x.getDayOfMonth(), 6, 2);
+        setDigits(x.getMonth(), 4, 2);
+        setDigits(x.getDay(), 6, 2);
         bytes[8] = '-';
-        setDigits(x.getHourOfDay(), 9, 2);
+        setDigits(x.getHour(), 9, 2);
         bytes[11] = ':';
-        setDigits(x.getMinuteOfHour(), 12, 2);
+        setDigits(x.getMinute(), 12, 2);
         bytes[14] = ':';
-        setDigits(x.getSecondOfMinute(), 15, 2);
+        setDigits(x.getSecond(), 15, 2);
         bytes[17] = '.';
-        setDigits(x.getMillisOfSecond(), 18, 3);
+        setDigits(x.getMilli(), 18, 3);
         bytes[21] = SOH;
 
         offset = 0;
@@ -641,16 +623,16 @@ public class FIXValue implements CharSequence {
      *
      * @param x a timestamp
      */
-    public void setTimestampSecs(ReadableDateTime x) {
+    public void setTimestampSecs(FIXTimestamp x) {
         setDigits(x.getYear(), 0, 4);
-        setDigits(x.getMonthOfYear(), 4, 2);
-        setDigits(x.getDayOfMonth(), 6, 2);
+        setDigits(x.getMonth(), 4, 2);
+        setDigits(x.getDay(), 6, 2);
         bytes[8] = '-';
-        setDigits(x.getHourOfDay(), 9, 2);
+        setDigits(x.getHour(), 9, 2);
         bytes[11] = ':';
-        setDigits(x.getMinuteOfHour(), 12, 2);
+        setDigits(x.getMinute(), 12, 2);
         bytes[14] = ':';
-        setDigits(x.getSecondOfMinute(), 15, 2);
+        setDigits(x.getSecond(), 15, 2);
         bytes[17] = SOH;
 
         offset = 0;

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXMessageTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXMessageTest.java
@@ -20,7 +20,6 @@ import static com.paritytrading.philadelphia.fix42.FIX42Tags.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.ByteBuffer;
-import org.joda.time.MutableDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ class FIXMessageTest {
 
     @Test
     void format() {
-        MutableDateTime timestamp = new MutableDateTime(2015, 9, 24, 9, 30, 5, 250);
+        FIXTimestamp timestamp = new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250);
 
         message.addField(ClOrdID).setString("123");
         message.addField(HandlInst).setChar(HandlInstValues.AutomatedExecutionNoIntervention);
@@ -68,7 +67,7 @@ class FIXMessageTest {
 
     @Test
     void print() {
-        MutableDateTime timestamp = new MutableDateTime(2015, 9, 24, 9, 30, 5, 250);
+        FIXTimestamp timestamp = new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250);
 
         message.addField(ClOrdID).setString("123");
         message.addField(HandlInst).setChar(HandlInstValues.AutomatedExecutionNoIntervention);

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXTimestampTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXTimestampTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class FIXTimestampTest {
+
+    @Test
+    void epoch() {
+        FIXTimestamp timestamp = new FIXTimestamp();
+
+        assertEquals(0, timestamp.getEpochMilli());
+
+        assertEquals(1970, timestamp.getYear());
+        assertEquals(1, timestamp.getMonth());
+        assertEquals(1, timestamp.getDay());
+        assertEquals(0, timestamp.getHour());
+        assertEquals(0, timestamp.getMinute());
+        assertEquals(0, timestamp.getSecond());
+        assertEquals(0, timestamp.getMilli());
+        assertEquals("19700101-00:00:00.000", timestamp.toString());
+    }
+
+    @Test
+    void setEpochMilli() {
+        FIXTimestamp timestamp = new FIXTimestamp();
+
+        timestamp.setEpochMilli(1650387150250L);
+
+        assertEquals(2022, timestamp.getYear());
+        assertEquals(4, timestamp.getMonth());
+        assertEquals(19, timestamp.getDay());
+        assertEquals(16, timestamp.getHour());
+        assertEquals(52, timestamp.getMinute());
+        assertEquals(30, timestamp.getSecond());
+        assertEquals(250, timestamp.getMilli());
+        assertEquals("20220419-16:52:30.250", timestamp.toString());
+    }
+
+}

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
-import org.joda.time.MutableDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -646,23 +645,23 @@ class FIXValueTest {
     void asDate() {
         get("20150924\u0001");
 
-        MutableDateTime d = new MutableDateTime(1970, 1, 1, 9, 30, 5, 250);
+        FIXTimestamp d = new FIXTimestamp(1970, 1, 1, 9, 30, 5, 250);
 
         value.asDate(d);
 
-        assertEquals(new MutableDateTime(2015, 9, 24, 0, 0, 0, 0), d);
+        assertEquals(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250), d);
     }
 
     @Test
     void notDate() {
         value.setString("FOO");
 
-        assertThrows(FIXValueFormatException.class, () -> value.asDate(new MutableDateTime()));
+        assertThrows(FIXValueFormatException.class, () -> value.asDate(new FIXTimestamp()));
     }
 
     @Test
     void setDate() {
-        value.setDate(new MutableDateTime(2015, 9, 24, 0, 0, 0, 0));
+        value.setDate(new FIXTimestamp(2015, 9, 24, 0, 0, 0, 0));
 
         assertEquals("20150924\u0001", put());
     }
@@ -671,41 +670,41 @@ class FIXValueTest {
     void asTimeOnlyWithMillis() {
         get("09:30:05.250\u0001");
 
-        MutableDateTime t = new MutableDateTime(2015, 9, 24, 22, 45, 10, 750);
+        FIXTimestamp t = new FIXTimestamp(2015, 9, 24, 22, 45, 10, 750);
 
         value.asTimeOnly(t);
 
-        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), t);
+        assertEquals(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250), t);
     }
 
     @Test
     void asTimeOnlyWithoutMillis() {
         get("09:30:05\u0001");
 
-        MutableDateTime t = new MutableDateTime(2015, 9, 24, 22, 45, 10, 750);
+        FIXTimestamp t = new FIXTimestamp(2015, 9, 24, 22, 45, 10, 750);
 
         value.asTimeOnly(t);
 
-        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 0), t);
+        assertEquals(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 0), t);
     }
 
     @Test
     void notTimeOnly() {
         value.setString("FOO");
 
-        assertThrows(FIXValueFormatException.class, () -> value.asTimeOnly(new MutableDateTime()));
+        assertThrows(FIXValueFormatException.class, () -> value.asTimeOnly(new FIXTimestamp()));
     }
 
     @Test
     void setTimeOnlyMillis() {
-        value.setTimeOnlyMillis(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
+        value.setTimeOnlyMillis(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250));
 
         assertEquals("09:30:05.250\u0001", put());
     }
 
     @Test
     void setTimeOnlySecs() {
-        value.setTimeOnlySecs(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
+        value.setTimeOnlySecs(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250));
 
         assertEquals("09:30:05\u0001", put());
     }
@@ -714,41 +713,41 @@ class FIXValueTest {
     void asTimestampWithMillis() {
         get("20150924-09:30:05.250\u0001");
 
-        MutableDateTime t = new MutableDateTime();
+        FIXTimestamp t = new FIXTimestamp();
 
         value.asTimestamp(t);
 
-        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250), t);
+        assertEquals(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250), t);
     }
 
     @Test
     void asTimestampWithoutMillis() {
         get("20150924-09:30.05\u0001");
 
-        MutableDateTime t = new MutableDateTime();
+        FIXTimestamp t = new FIXTimestamp();
 
         value.asTimestamp(t);
 
-        assertEquals(new MutableDateTime(2015, 9, 24, 9, 30, 5, 0), t);
+        assertEquals(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 0), t);
     }
 
     @Test
     void notTimestamp() {
         value.setString("FOO");
 
-        assertThrows(FIXValueFormatException.class, () -> value.asTimestamp(new MutableDateTime()));
+        assertThrows(FIXValueFormatException.class, () -> value.asTimestamp(new FIXTimestamp()));
     }
 
     @Test
     void setTimestampMillis() {
-        value.setTimestampMillis(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
+        value.setTimestampMillis(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250));
 
         assertEquals("20150924-09:30:05.250\u0001", put());
     }
 
     @Test
     void setTimestampSecs() {
-        value.setTimestampSecs(new MutableDateTime(2015, 9, 24, 9, 30, 5, 250));
+        value.setTimestampSecs(new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250));
 
         assertEquals("20150924-09:30:05\u0001", put());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,6 @@
         <version>3.19.0</version>
       </dependency>
       <dependency>
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time</artifactId>
-        <version>2.10.10</version> <!-- (mentioned in documentation) -->
-      </dependency>
-      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.12.0</version>
@@ -216,9 +211,6 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <excludePackageNames>com.paritytrading.philadelphia.acceptor:com.paritytrading.philadelphia.client:com.paritytrading.philadelphia.initiator:*.generated</excludePackageNames>
-          <links>
-            <link>http://www.joda.org/joda-time/apidocs/</link>
-          </links>
           <sourceFileExcludes>**\/*Benchmark.java</sourceFileExcludes>
         </configuration>
       </plugin>

--- a/tests/perf-test/pom.xml
+++ b/tests/perf-test/pom.xml
@@ -40,10 +40,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
     </dependency>

--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXValueBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXValueBenchmark.java
@@ -15,7 +15,6 @@
  */
 package com.paritytrading.philadelphia;
 
-import org.joda.time.MutableDateTime;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Setup;
@@ -26,11 +25,17 @@ public class FIXValueBenchmark extends FIXBenchmark {
 
     private StringBuilder string;
 
-    private MutableDateTime date;
+    private FIXTimestamp date;
 
-    private MutableDateTime timeOnly;
+    private FIXTimestamp timeOnly;
 
-    private MutableDateTime timestamp;
+    private FIXTimestamp timestamp;
+
+    private long dateMillis;
+
+    private long timeOnlyMillis;
+
+    private long timestampMillis;
 
     private FIXValue booleanValue;
 
@@ -54,11 +59,15 @@ public class FIXValueBenchmark extends FIXBenchmark {
     public void prepare() {
         string = new StringBuilder(32);
 
-        date = new MutableDateTime(2015, 9, 24, 0, 0, 0, 0);
+        date = new FIXTimestamp(2015, 9, 24, 0, 0, 0, 0);
 
-        timeOnly = new MutableDateTime(2015, 9, 24, 9, 30, 5, 250);
+        timeOnly = new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250);
 
-        timestamp = new MutableDateTime(2015, 9, 24, 9, 30, 5, 250);
+        timestamp = new FIXTimestamp(2015, 9, 24, 9, 30, 5, 250);
+
+        dateMillis = date.getEpochMilli();
+        timeOnlyMillis = timeOnly.getEpochMilli();
+        timestampMillis = timestamp.getEpochMilli();
 
         booleanValue = new FIXValue(64);
         booleanValue.setBoolean(true);
@@ -155,38 +164,44 @@ public class FIXValueBenchmark extends FIXBenchmark {
     }
 
     @Benchmark
-    public MutableDateTime asDate() {
+    public long asDate() {
         dateValue.asDate(date);
 
-        return date;
+        return date.getEpochMilli();
     }
 
     @Benchmark
     public void setDate() {
+        date.setEpochMilli(dateMillis);
+
         dateValue.setDate(date);
     }
 
     @Benchmark
-    public MutableDateTime asTimeOnly() {
+    public long asTimeOnly() {
         timeOnlyValue.asTimeOnly(timeOnly);
 
-        return timeOnly;
+        return timeOnly.getEpochMilli();
     }
 
     @Benchmark
     public void setTimeOnly() {
+        timeOnly.setEpochMilli(timeOnlyMillis);
+
         timeOnlyValue.setTimeOnlySecs(timeOnly);
     }
 
     @Benchmark
-    public MutableDateTime asTimestamp() {
+    public long asTimestamp() {
         timestampValue.asTimestamp(timestamp);
 
-        return timestamp;
+        return timestamp.getEpochMilli();
     }
 
     @Benchmark
     public void setTimestamp() {
+        timestamp.setEpochMilli(timestampMillis);
+
         timestampValue.setTimestampMillis(timestamp);
     }
 


### PR DESCRIPTION
Replace `MutableDateTime` usage with a `FIXTimestamp` class, and remove the Joda-Time 2.x dependency. In addition to removing the dependency, this improves the performance significantly.

  Benchmark |                     Baseline |Candidate
  ------------------------------|--------|---------
  FIXValueBenchmark.asDate         |  1.00 |     0.46
  FIXValueBenchmark.asTimeOnly   |    1.00 |     0.38
  FIXValueBenchmark.asTimestamp |     1.00 |     0.49
  FIXValueBenchmark.setDate          |1.00  |    0.68
  FIXValueBenchmark.setTimeOnly   |   1.00 |     0.44
  FIXValueBenchmark.setTimestamp |    1.00 |     0.31

Note that the benchmarks above include both parsing or formatting the values to or from bytes as well as converting the timestamps to or from numbers of milliseconds from the epoch.