### PR TITLE
Allow to pass other channel types

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/Messages.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/Messages.java
@@ -19,10 +19,11 @@ import com.paritytrading.philadelphia.FIXConnection;
 import com.paritytrading.philadelphia.FIXConnectionStatusListener;
 import com.paritytrading.philadelphia.FIXMessage;
 import com.paritytrading.philadelphia.FIXMessageListener;
+import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
 
-class Messages implements FIXMessageListener, FIXConnectionStatusListener {
+class Messages implements FIXMessageListener, FIXConnectionStatusListener<SocketChannel> {
 
     private final List<Message> messages;
 
@@ -40,33 +41,33 @@ class Messages implements FIXMessageListener, FIXConnectionStatusListener {
     }
 
     @Override
-    public void close(FIXConnection connection, String message) {
+    public void close(FIXConnection<SocketChannel> connection, String message) {
     }
 
     @Override
-    public void sequenceReset(FIXConnection connection) {
+    public void sequenceReset(FIXConnection<SocketChannel> connection) {
     }
 
     @Override
-    public void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
+    public void tooLowMsgSeqNum(FIXConnection<SocketChannel> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
     }
 
     @Override
-    public void heartbeatTimeout(FIXConnection connection) {
+    public void heartbeatTimeout(FIXConnection<SocketChannel> connection) {
     }
 
     @Override
-    public void reject(FIXConnection connection, FIXMessage message) {
+    public void reject(FIXConnection<SocketChannel> connection, FIXMessage message) {
         add(message);
     }
 
     @Override
-    public void logon(FIXConnection connection, FIXMessage message) {
+    public void logon(FIXConnection<SocketChannel> connection, FIXMessage message) {
         add(message);
     }
 
     @Override
-    public void logout(FIXConnection connection, FIXMessage message) {
+    public void logout(FIXConnection<SocketChannel> connection, FIXMessage message) {
         add(message);
     }
 

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/Session.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/Session.java
@@ -33,13 +33,13 @@ class Session implements Closeable {
 
     private final Selector selector;
 
-    private final FIXConnection connection;
+    private final FIXConnection<SocketChannel> connection;
 
     private volatile boolean closed;
 
     private final Object lock;
 
-    private Session(Selector selector, FIXConnection connection) {
+    private Session(Selector selector, FIXConnection<SocketChannel> connection) {
         this.txMessage = connection.create();
 
         this.selector = selector;
@@ -58,7 +58,7 @@ class Session implements Closeable {
 
     static Session open(InetSocketAddress address,
             FIXConfig config, FIXMessageListener listener,
-            FIXConnectionStatusListener statusListener) throws IOException {
+            FIXConnectionStatusListener<SocketChannel> statusListener) throws IOException {
         SocketChannel channel = SocketChannel.open();
 
         channel.connect(address);
@@ -68,7 +68,7 @@ class Session implements Closeable {
 
         channel.register(selector, SelectionKey.OP_READ);
 
-        FIXConnection connection = new FIXConnection(channel, config, listener, statusListener);
+        FIXConnection<SocketChannel> connection = new FIXConnection<>(channel, config, listener, statusListener);
 
         return new Session(selector, connection);
     }
@@ -78,7 +78,7 @@ class Session implements Closeable {
         closed = true;
     }
 
-    FIXConnection getConnection() {
+    FIXConnection<SocketChannel> getConnection() {
         return connection;
     }
 

--- a/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
+++ b/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
@@ -32,7 +32,7 @@ class Session implements FIXMessageListener {
 
     private static final FIXConfig CONFIG = new FIXConfig.Builder().build();
 
-    private final FIXConnection connection;
+    private final FIXConnection<SocketChannel> connection;
 
     private final FIXMessage report;
 
@@ -49,32 +49,32 @@ class Session implements FIXMessageListener {
     private long nextExecId;
 
     Session(SocketChannel channel) {
-        connection = new FIXConnection(channel, CONFIG, this, new FIXConnectionStatusListener() {
+        connection = new FIXConnection<>(channel, CONFIG, this, new FIXConnectionStatusListener<SocketChannel>() {
 
             @Override
-            public void close(FIXConnection connection, String message) throws IOException {
+            public void close(FIXConnection<SocketChannel> connection, String message) throws IOException {
                 connection.close();
             }
 
             @Override
-            public void sequenceReset(FIXConnection connection) {
+            public void sequenceReset(FIXConnection<SocketChannel> connection) {
             }
 
             @Override
-            public void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
+            public void tooLowMsgSeqNum(FIXConnection<SocketChannel> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
             }
 
             @Override
-            public void heartbeatTimeout(FIXConnection connection) throws IOException {
+            public void heartbeatTimeout(FIXConnection<SocketChannel> connection) throws IOException {
                 connection.close();
             }
 
             @Override
-            public void reject(FIXConnection connection, FIXMessage message) throws IOException {
+            public void reject(FIXConnection<SocketChannel> connection, FIXMessage message) throws IOException {
             }
 
             @Override
-            public void logon(FIXConnection connection, FIXMessage message) throws IOException {
+            public void logon(FIXConnection<SocketChannel> connection, FIXMessage message) throws IOException {
                 connection.sendLogon(true);
 
                 report.valueOf(SenderCompID).setString(connection.getSenderCompID());
@@ -82,7 +82,7 @@ class Session implements FIXMessageListener {
             }
 
             @Override
-            public void logout(FIXConnection connection, FIXMessage message) throws IOException {
+            public void logout(FIXConnection<SocketChannel> connection, FIXMessage message) throws IOException {
                 connection.sendLogout();
             }
 
@@ -171,7 +171,7 @@ class Session implements FIXMessageListener {
         connection.send(report);
     }
 
-    FIXConnection getConnection() {
+    FIXConnection<SocketChannel> getConnection() {
         return connection;
     }
 

--- a/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
+++ b/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
@@ -37,7 +37,7 @@ class Initiator implements FIXMessageListener, Closeable {
         .setTargetCompID("acceptor")
         .build();
 
-    private final FIXConnection connection;
+    private final FIXConnection<SocketChannel> connection;
 
     private final Histogram histogram;
 
@@ -46,36 +46,36 @@ class Initiator implements FIXMessageListener, Closeable {
     private int receiveCount;
 
     private Initiator(SocketChannel channel) {
-        connection = new FIXConnection(channel, CONFIG, this, new FIXConnectionStatusListener() {
+        connection = new FIXConnection<>(channel, CONFIG, this, new FIXConnectionStatusListener<SocketChannel>() {
 
             @Override
-            public void close(FIXConnection connection, String message) throws IOException {
+            public void close(FIXConnection<SocketChannel> connection, String message) throws IOException {
                 connection.close();
             }
 
             @Override
-            public void sequenceReset(FIXConnection connection) {
+            public void sequenceReset(FIXConnection<SocketChannel> connection) {
             }
 
             @Override
-            public void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
+            public void tooLowMsgSeqNum(FIXConnection<SocketChannel> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
             }
 
             @Override
-            public void heartbeatTimeout(FIXConnection connection) throws IOException {
+            public void heartbeatTimeout(FIXConnection<SocketChannel> connection) throws IOException {
                 connection.close();
             }
 
             @Override
-            public void reject(FIXConnection connection, FIXMessage message) throws IOException {
+            public void reject(FIXConnection<SocketChannel> connection, FIXMessage message) throws IOException {
             }
 
             @Override
-            public void logon(FIXConnection connection, FIXMessage message) throws IOException {
+            public void logon(FIXConnection<SocketChannel> connection, FIXMessage message) throws IOException {
             }
 
             @Override
-            public void logout(FIXConnection connection, FIXMessage message) throws IOException {
+            public void logout(FIXConnection<SocketChannel> connection, FIXMessage message) throws IOException {
                 connection.sendLogout();
             }
 
@@ -111,7 +111,7 @@ class Initiator implements FIXMessageListener, Closeable {
         return histogram;
     }
 
-    FIXConnection getTransport() {
+    FIXConnection<SocketChannel> getTransport() {
         return connection;
     }
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -23,16 +23,17 @@ import static com.paritytrading.philadelphia.FIXTags.*;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.SocketChannel;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ReadableByteChannel;
 
 /**
  * A connection.
  */
-public class FIXConnection implements Closeable {
+public class FIXConnection<CHANNEL extends ReadableByteChannel & GatheringByteChannel> implements Closeable {
 
     private static final int CURRENT_TIMESTAMP_FIELD_CAPACITY = 24;
 
-    private final SocketChannel channel;
+    private final CHANNEL channel;
 
     private final FIXConfig config;
 
@@ -77,7 +78,7 @@ public class FIXConnection implements Closeable {
 
     private final FIXMessageParser parser;
 
-    private final FIXConnectionStatusListener statusListener;
+    private final FIXConnectionStatusListener<CHANNEL> statusListener;
 
     private final FIXMessage txMessage;
 
@@ -96,8 +97,8 @@ public class FIXConnection implements Closeable {
      * @param listener the inbound message listener
      * @param statusListener the inbound status event listener
      */
-    public FIXConnection(SocketChannel channel, FIXConfig config, FIXMessageListener listener,
-            FIXConnectionStatusListener statusListener) {
+    public FIXConnection(CHANNEL channel, FIXConfig config, FIXMessageListener listener,
+            FIXConnectionStatusListener<CHANNEL> statusListener) {
         this.channel = channel;
 
         this.config = config;
@@ -157,7 +158,7 @@ public class FIXConnection implements Closeable {
      *
      * @return the underlying socket channel
      */
-    public SocketChannel getChannel() {
+    public CHANNEL getChannel() {
         return channel;
     }
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusListener.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusListener.java
@@ -16,11 +16,13 @@
 package com.paritytrading.philadelphia;
 
 import java.io.IOException;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ReadableByteChannel;
 
 /**
  * The interface for inbound status events.
  */
-public interface FIXConnectionStatusListener {
+public interface FIXConnectionStatusListener<CHANNEL extends ReadableByteChannel & GatheringByteChannel> {
 
     /**
      * Receive an indication to close the connection.
@@ -29,7 +31,7 @@ public interface FIXConnectionStatusListener {
      * @param message a detail message
      * @throws IOException if an I/O error occurs
      */
-    void close(FIXConnection connection, String message) throws IOException;
+    void close(FIXConnection<CHANNEL> connection, String message) throws IOException;
 
     /**
      * Receive an indication of a sequence reset.
@@ -37,7 +39,7 @@ public interface FIXConnectionStatusListener {
      * @param connection the connection
      * @throws IOException if an I/O error occurs
      */
-    void sequenceReset(FIXConnection connection) throws IOException;
+    void sequenceReset(FIXConnection<CHANNEL> connection) throws IOException;
 
     /**
      * Receive an indication of a message with too low MsgSeqNum(34) and
@@ -48,7 +50,7 @@ public interface FIXConnectionStatusListener {
      * @param expectedMsgSeqNum the expected MsgSeqNum(34)
      * @throws IOException if an I/O error occurs
      */
-    void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) throws IOException;
+    void tooLowMsgSeqNum(FIXConnection<CHANNEL> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) throws IOException;
 
     /**
      * Receive an indication of a heartbeat timeout.
@@ -56,7 +58,7 @@ public interface FIXConnectionStatusListener {
      * @param connection the connection
      * @throws IOException if an I/O error occurs
      */
-    void heartbeatTimeout(FIXConnection connection) throws IOException;
+    void heartbeatTimeout(FIXConnection<CHANNEL> connection) throws IOException;
 
     /**
      * Receive a Reject(3) message.
@@ -65,7 +67,7 @@ public interface FIXConnectionStatusListener {
      * @param message the Reject(3) message
      * @throws IOException if an I/O error occurs
      */
-    void reject(FIXConnection connection, FIXMessage message) throws IOException;
+    void reject(FIXConnection<CHANNEL> connection, FIXMessage message) throws IOException;
 
     /**
      * Receive a Logon(A) message.
@@ -74,7 +76,7 @@ public interface FIXConnectionStatusListener {
      * @param message the Logon(A) message
      * @throws IOException if an I/O error occurs
      */
-    void logon(FIXConnection connection, FIXMessage message) throws IOException;
+    void logon(FIXConnection<CHANNEL> connection, FIXMessage message) throws IOException;
 
     /**
      * Receive a Logout(5) message.
@@ -83,6 +85,6 @@ public interface FIXConnectionStatusListener {
      * @param message the Logout(5) message
      * @throws IOException if an I/O error occurs
      */
-    void logout(FIXConnection connection, FIXMessage message) throws IOException;
+    void logout(FIXConnection<CHANNEL> connection, FIXMessage message) throws IOException;
 
 }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
@@ -15,10 +15,12 @@
  */
 package com.paritytrading.philadelphia;
 
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 
-class FIXConnectionStatus implements FIXConnectionStatusListener {
+class FIXConnectionStatus<CHANNEL extends ReadableByteChannel & GatheringByteChannel> implements FIXConnectionStatusListener<CHANNEL> {
 
     private List<Event> events;
 
@@ -31,37 +33,37 @@ class FIXConnectionStatus implements FIXConnectionStatusListener {
     }
 
     @Override
-    public void close(FIXConnection connection, String message) {
+    public void close(FIXConnection<CHANNEL> connection, String message) {
         events.add(new Close(message));
     }
 
     @Override
-    public void sequenceReset(FIXConnection connection) {
+    public void sequenceReset(FIXConnection<CHANNEL> connection) {
         events.add(new SequenceReset());
     }
 
     @Override
-    public void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
+    public void tooLowMsgSeqNum(FIXConnection<CHANNEL> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
         events.add(new TooLowMsgSeqNum(receivedMsgSeqNum, expectedMsgSeqNum));
     }
 
     @Override
-    public void heartbeatTimeout(FIXConnection connection) {
+    public void heartbeatTimeout(FIXConnection<CHANNEL> connection) {
         events.add(new HeartbeatTimeout());
     }
 
     @Override
-    public void reject(FIXConnection connection, FIXMessage message) {
+    public void reject(FIXConnection<CHANNEL> connection, FIXMessage message) {
         events.add(new Reject());
     }
 
     @Override
-    public void logon(FIXConnection connection, FIXMessage message) {
+    public void logon(FIXConnection<CHANNEL> connection, FIXMessage message) {
         events.add(new Logon());
     }
 
     @Override
-    public void logout(FIXConnection connection, FIXMessage message) {
+    public void logout(FIXConnection<CHANNEL> connection, FIXMessage message) {
         events.add(new Logout());
     }
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorPipeChannelTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorPipeChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Philadelphia authors
+ * Copyright 2022 Philadelphia authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,18 @@
  */
 package com.paritytrading.philadelphia;
 
-import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.nio.channels.Pipe;
 
-class FIXConfigTest {
+class FIXInitiatorPipeChannelTest extends FIXInitiatorTest<PipeChannel> {
+    @Override
+    protected Channels createChannels() throws IOException {
+        Pipe up = Pipe.open();
+        Pipe down = Pipe.open();
 
-    @SuppressWarnings("resource")
-    @Test
-    void fixt11() {
-        FIXConfig config = new FIXConfig.Builder()
-                .setVersion(FIXVersion.FIXT_1_1)
-                .build();
-        new FIXConnection<>(null, config, null, null);
+        Channels channels = new Channels();
+        channels.initiator = new PipeChannel(up.sink(), down.source());
+        channels.acceptor = new PipeChannel(down.sink(), up.source());
+        return channels;
     }
-
 }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorSocketChannelTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorSocketChannelTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+import java.io.IOException;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+class FIXInitiatorSocketChannelTest extends FIXInitiatorTest<SocketChannel> {
+    @Override
+    protected Channels createChannels() throws IOException {
+        ServerSocketChannel acceptorServerChannel = ServerSocketChannel.open();
+        acceptorServerChannel.bind(null);
+
+        Channels channels = new Channels();
+        channels.initiator = SocketChannel.open(acceptorServerChannel.getLocalAddress());
+        channels.initiator.configureBlocking(false);
+
+        SocketChannel acceptor = acceptorServerChannel.accept();
+        acceptor.configureBlocking(false);
+        channels.acceptor = acceptor;
+
+        acceptorServerChannel.close();
+        return channels;
+    }
+}

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/PipeChannel.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/PipeChannel.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.Pipe;
+import java.nio.channels.ScatteringByteChannel;
+
+class PipeChannel implements ByteChannel, ScatteringByteChannel, GatheringByteChannel {
+    private final Pipe.SinkChannel sink;
+    private final Pipe.SourceChannel source;
+
+    public PipeChannel(Pipe.SinkChannel sink, Pipe.SourceChannel source)  throws IOException {
+        this.sink = sink;
+        this.source = source;
+        sink.configureBlocking(false);
+        source.configureBlocking(false);
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return sink.write(srcs, offset, length);
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs) throws IOException {
+        return sink.write(srcs);
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return sink.write(src);
+    }
+
+    @Override
+    public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+        return source.read(dsts, offset, length);
+    }
+
+    @Override
+    public long read(ByteBuffer[] dsts) throws IOException {
+        return source.read(dsts);
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        return source.read(dst);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return sink.isOpen() && source.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        sink.close();
+        source.close();
+    }
+}

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/TestConnection.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/TestConnection.java
@@ -21,19 +21,19 @@ import static java.util.Arrays.*;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.SocketChannel;
+import java.nio.channels.ByteChannel;
 import java.util.List;
 
 class TestConnection implements Closeable {
 
-    private SocketChannel channel;
+    private ByteChannel channel;
 
     private ByteBuffer rxBuffer;
     private ByteBuffer txBuffer;
 
     private TestMessageParser parser;
 
-    TestConnection(SocketChannel channel, TestMessageListener listener) {
+    TestConnection(ByteChannel channel, TestMessageListener listener) {
         this.channel = channel;
 
         this.parser = new TestMessageParser(listener);


### PR DESCRIPTION
Raising this pull request as a proposal for issue #236 

The change changes the raw signature of `FIXConnection.getChannel()` in backwards incompatible way. The migration fix for existing usages would be to either specify generic parameter or to downcast.

I have made the `FIXInitiatorTest` abstract and pushed the current implementation into a `FIXInitiatorSocketTest` subclass. I have also added `FIXInitiatorPipeTest`  as an example of how to use the new functionality.