### PR TITLE
FIXConnection changes to support more Channel types (Solution 1)

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/Messages.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/Messages.java
@@ -40,33 +40,33 @@ class Messages implements FIXMessageListener, FIXConnectionStatusListener {
     }
 
     @Override
-    public void close(FIXConnection connection, String message) {
+    public void close(FIXConnection<?> connection, String message) {
     }
 
     @Override
-    public void sequenceReset(FIXConnection connection) {
+    public void sequenceReset(FIXConnection<?> connection) {
     }
 
     @Override
-    public void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
+    public void tooLowMsgSeqNum(FIXConnection<?> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
     }
 
     @Override
-    public void heartbeatTimeout(FIXConnection connection) {
+    public void heartbeatTimeout(FIXConnection<?> connection) {
     }
 
     @Override
-    public void reject(FIXConnection connection, FIXMessage message) {
+    public void reject(FIXConnection<?> connection, FIXMessage message) {
         add(message);
     }
 
     @Override
-    public void logon(FIXConnection connection, FIXMessage message) {
+    public void logon(FIXConnection<?> connection, FIXMessage message) {
         add(message);
     }
 
     @Override
-    public void logout(FIXConnection connection, FIXMessage message) {
+    public void logout(FIXConnection<?> connection, FIXMessage message) {
         add(message);
     }
 

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/Session.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/Session.java
@@ -33,13 +33,13 @@ class Session implements Closeable {
 
     private final Selector selector;
 
-    private final FIXConnection connection;
+    private final FIXConnection<?> connection;
 
     private volatile boolean closed;
 
     private final Object lock;
 
-    private Session(Selector selector, FIXConnection connection) {
+    private Session(Selector selector, FIXConnection<?> connection) {
         this.txMessage = connection.create();
 
         this.selector = selector;
@@ -68,7 +68,7 @@ class Session implements Closeable {
 
         channel.register(selector, SelectionKey.OP_READ);
 
-        FIXConnection connection = new FIXConnection(channel, config, listener, statusListener);
+        FIXConnection<SocketChannel> connection = new FIXConnection<>(channel, config, listener, statusListener);
 
         return new Session(selector, connection);
     }
@@ -78,7 +78,7 @@ class Session implements Closeable {
         closed = true;
     }
 
-    FIXConnection getConnection() {
+    FIXConnection<?> getConnection() {
         return connection;
     }
 

--- a/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
+++ b/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
@@ -32,7 +32,7 @@ class Session implements FIXMessageListener {
 
     private static final FIXConfig CONFIG = new FIXConfig.Builder().build();
 
-    private final FIXConnection connection;
+    private final FIXConnection<?> connection;
 
     private final FIXMessage report;
 
@@ -49,32 +49,32 @@ class Session implements FIXMessageListener {
     private long nextExecId;
 
     Session(SocketChannel channel) {
-        connection = new FIXConnection(channel, CONFIG, this, new FIXConnectionStatusListener() {
+        connection = new FIXConnection<>(channel, CONFIG, this, new FIXConnectionStatusListener() {
 
             @Override
-            public void close(FIXConnection connection, String message) throws IOException {
+            public void close(FIXConnection<?> connection, String message) throws IOException {
                 connection.close();
             }
 
             @Override
-            public void sequenceReset(FIXConnection connection) {
+            public void sequenceReset(FIXConnection<?> connection) {
             }
 
             @Override
-            public void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
+            public void tooLowMsgSeqNum(FIXConnection<?> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
             }
 
             @Override
-            public void heartbeatTimeout(FIXConnection connection) throws IOException {
+            public void heartbeatTimeout(FIXConnection<?> connection) throws IOException {
                 connection.close();
             }
 
             @Override
-            public void reject(FIXConnection connection, FIXMessage message) throws IOException {
+            public void reject(FIXConnection<?> connection, FIXMessage message) throws IOException {
             }
 
             @Override
-            public void logon(FIXConnection connection, FIXMessage message) throws IOException {
+            public void logon(FIXConnection<?> connection, FIXMessage message) throws IOException {
                 connection.sendLogon(true);
 
                 report.valueOf(SenderCompID).setString(connection.getSenderCompID());
@@ -82,7 +82,7 @@ class Session implements FIXMessageListener {
             }
 
             @Override
-            public void logout(FIXConnection connection, FIXMessage message) throws IOException {
+            public void logout(FIXConnection<?> connection, FIXMessage message) throws IOException {
                 connection.sendLogout();
             }
 
@@ -171,7 +171,7 @@ class Session implements FIXMessageListener {
         connection.send(report);
     }
 
-    FIXConnection getConnection() {
+    FIXConnection<?> getConnection() {
         return connection;
     }
 

--- a/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
+++ b/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
@@ -37,7 +37,7 @@ class Initiator implements FIXMessageListener, Closeable {
         .setTargetCompID("acceptor")
         .build();
 
-    private final FIXConnection connection;
+    private final FIXConnection<SocketChannel> connection;
 
     private final Histogram histogram;
 
@@ -46,36 +46,36 @@ class Initiator implements FIXMessageListener, Closeable {
     private int receiveCount;
 
     private Initiator(SocketChannel channel) {
-        connection = new FIXConnection(channel, CONFIG, this, new FIXConnectionStatusListener() {
+        connection = new FIXConnection<>(channel, CONFIG, this, new FIXConnectionStatusListener() {
 
             @Override
-            public void close(FIXConnection connection, String message) throws IOException {
+            public void close(FIXConnection<?> connection, String message) throws IOException {
                 connection.close();
             }
 
             @Override
-            public void sequenceReset(FIXConnection connection) {
+            public void sequenceReset(FIXConnection<?> connection) {
             }
 
             @Override
-            public void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
+            public void tooLowMsgSeqNum(FIXConnection<?> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
             }
 
             @Override
-            public void heartbeatTimeout(FIXConnection connection) throws IOException {
+            public void heartbeatTimeout(FIXConnection<?> connection) throws IOException {
                 connection.close();
             }
 
             @Override
-            public void reject(FIXConnection connection, FIXMessage message) throws IOException {
+            public void reject(FIXConnection<?> connection, FIXMessage message) throws IOException {
             }
 
             @Override
-            public void logon(FIXConnection connection, FIXMessage message) throws IOException {
+            public void logon(FIXConnection<?> connection, FIXMessage message) throws IOException {
             }
 
             @Override
-            public void logout(FIXConnection connection, FIXMessage message) throws IOException {
+            public void logout(FIXConnection<?> connection, FIXMessage message) throws IOException {
                 connection.sendLogout();
             }
 
@@ -111,7 +111,7 @@ class Initiator implements FIXMessageListener, Closeable {
         return histogram;
     }
 
-    FIXConnection getTransport() {
+    FIXConnection<?> getTransport() {
         return connection;
     }
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -23,6 +23,8 @@ import static com.paritytrading.philadelphia.FIXTags.*;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SocketChannel;
 import org.joda.time.DateTimeZone;
 import org.joda.time.MutableDateTime;
@@ -30,11 +32,11 @@ import org.joda.time.MutableDateTime;
 /**
  * A connection.
  */
-public class FIXConnection implements Closeable {
+public class FIXConnection<T extends ReadableByteChannel & GatheringByteChannel> implements Closeable {
 
     private static final int CURRENT_TIMESTAMP_FIELD_CAPACITY = 24;
 
-    private final SocketChannel channel;
+    private final T channel;
 
     private final FIXConfig config;
 
@@ -98,7 +100,7 @@ public class FIXConnection implements Closeable {
      * @param listener the inbound message listener
      * @param statusListener the inbound status event listener
      */
-    public FIXConnection(SocketChannel channel, FIXConfig config, FIXMessageListener listener,
+    public FIXConnection(T channel, FIXConfig config, FIXMessageListener listener,
             FIXConnectionStatusListener statusListener) {
         this.channel = channel;
 
@@ -159,7 +161,7 @@ public class FIXConnection implements Closeable {
      *
      * @return the underlying socket channel
      */
-    public SocketChannel getChannel() {
+    public T getChannel() {
         return channel;
     }
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusListener.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusListener.java
@@ -29,7 +29,7 @@ public interface FIXConnectionStatusListener {
      * @param message a detail message
      * @throws IOException if an I/O error occurs
      */
-    void close(FIXConnection connection, String message) throws IOException;
+    void close(FIXConnection<?> connection, String message) throws IOException;
 
     /**
      * Receive an indication of a sequence reset.
@@ -37,7 +37,7 @@ public interface FIXConnectionStatusListener {
      * @param connection the connection
      * @throws IOException if an I/O error occurs
      */
-    void sequenceReset(FIXConnection connection) throws IOException;
+    void sequenceReset(FIXConnection<?> connection) throws IOException;
 
     /**
      * Receive an indication of a message with too low MsgSeqNum(34) and
@@ -48,7 +48,7 @@ public interface FIXConnectionStatusListener {
      * @param expectedMsgSeqNum the expected MsgSeqNum(34)
      * @throws IOException if an I/O error occurs
      */
-    void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) throws IOException;
+    void tooLowMsgSeqNum(FIXConnection<?> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) throws IOException;
 
     /**
      * Receive an indication of a heartbeat timeout.
@@ -56,7 +56,7 @@ public interface FIXConnectionStatusListener {
      * @param connection the connection
      * @throws IOException if an I/O error occurs
      */
-    void heartbeatTimeout(FIXConnection connection) throws IOException;
+    void heartbeatTimeout(FIXConnection<?> connection) throws IOException;
 
     /**
      * Receive a Reject(3) message.
@@ -65,7 +65,7 @@ public interface FIXConnectionStatusListener {
      * @param message the Reject(3) message
      * @throws IOException if an I/O error occurs
      */
-    void reject(FIXConnection connection, FIXMessage message) throws IOException;
+    void reject(FIXConnection<?> connection, FIXMessage message) throws IOException;
 
     /**
      * Receive a Logon(A) message.
@@ -74,7 +74,7 @@ public interface FIXConnectionStatusListener {
      * @param message the Logon(A) message
      * @throws IOException if an I/O error occurs
      */
-    void logon(FIXConnection connection, FIXMessage message) throws IOException;
+    void logon(FIXConnection<?> connection, FIXMessage message) throws IOException;
 
     /**
      * Receive a Logout(5) message.
@@ -83,6 +83,6 @@ public interface FIXConnectionStatusListener {
      * @param message the Logout(5) message
      * @throws IOException if an I/O error occurs
      */
-    void logout(FIXConnection connection, FIXMessage message) throws IOException;
+    void logout(FIXConnection<?> connection, FIXMessage message) throws IOException;
 
 }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConfigTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConfigTest.java
@@ -25,7 +25,7 @@ class FIXConfigTest {
         FIXConfig config = new FIXConfig.Builder()
                 .setVersion(FIXVersion.FIXT_1_1)
                 .build();
-        new FIXConnection(null, config, null, null);
+        new FIXConnection<>(null, config, null, null);
     }
 
 }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
@@ -31,37 +31,37 @@ class FIXConnectionStatus implements FIXConnectionStatusListener {
     }
 
     @Override
-    public void close(FIXConnection connection, String message) {
+    public void close(FIXConnection<?> connection, String message) {
         events.add(new Close(message));
     }
 
     @Override
-    public void sequenceReset(FIXConnection connection) {
+    public void sequenceReset(FIXConnection<?> connection) {
         events.add(new SequenceReset());
     }
 
     @Override
-    public void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
+    public void tooLowMsgSeqNum(FIXConnection<?> connection, long receivedMsgSeqNum, long expectedMsgSeqNum) {
         events.add(new TooLowMsgSeqNum(receivedMsgSeqNum, expectedMsgSeqNum));
     }
 
     @Override
-    public void heartbeatTimeout(FIXConnection connection) {
+    public void heartbeatTimeout(FIXConnection<?> connection) {
         events.add(new HeartbeatTimeout());
     }
 
     @Override
-    public void reject(FIXConnection connection, FIXMessage message) {
+    public void reject(FIXConnection<?> connection, FIXMessage message) {
         events.add(new Reject());
     }
 
     @Override
-    public void logon(FIXConnection connection, FIXMessage message) {
+    public void logon(FIXConnection<?> connection, FIXMessage message) {
         events.add(new Logon());
     }
 
     @Override
-    public void logout(FIXConnection connection, FIXMessage message) {
+    public void logout(FIXConnection<?> connection, FIXMessage message) {
         events.add(new Logout());
     }
 


### PR DESCRIPTION
hi,
this solution relies on generics to allow FIXConnection to specify the 2 interfaces in Channel that it needs:

public class FIXConnection<T extends ReadableByteChannel & GatheringByteChannel> implements Closeable {

The drawbacks on this is that now FIXConnection is generic and that might not be of everyone's taste.

I will shortly post another PR with an alternative solution based on a new interface