### PR TITLE
philadelphia-core: Clean up test

### DIFF
--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -77,7 +77,8 @@ class FIXInitiatorTest {
         initiator.keepAlive();
 
         acceptor.send("35=0|34=1|");
-        receiveBlocking(initiator);
+        while (initiator.getIncomingMsgSeqNum() != 2)
+            initiator.receive();
 
         initiator.setCurrentTimeMillis(35_000);
         initiator.keepAlive();
@@ -114,7 +115,8 @@ class FIXInitiatorTest {
 
         acceptor.send("35=0|34=1|");
 
-        receiveBlocking(initiator);
+        while (initiator.getIncomingMsgSeqNum() != 2)
+            initiator.receive();
 
         initiator.setCurrentTimeMillis(60_000);
         initiator.keepAlive();
@@ -406,22 +408,6 @@ class FIXInitiatorTest {
                 "11=1|21=1|55=FOO|54=1|60=19700101-00:00:00.000|38=100.00|40=2|44=25.50|10=020|");
 
         initiatorMessages(messages);
-    }
-
-    private void receiveBlocking(FIXConnection connection) throws IOException {
-        SocketChannel channel = connection.getChannel();
-
-        if (channel.isBlocking()) {
-            connection.receive();
-        } else {
-            channel.configureBlocking(true);
-
-            try {
-                connection.receive();
-            } finally {
-                channel.configureBlocking(false);
-            }
-        }
     }
 
     private void initiatorMessage(String message) throws IOException {


### PR DESCRIPTION
The test uses blocking I/O to ensure that the implementation under test receives Heartbeat(0) messages. This is because a Heartbeat(0) message does not have a callback unlike, for example, a Logon(A) message.

Make the test simpler by replacing blocking I/O with a MsgSeqNum(34) check. Although a Heartbeat(0) message does not invoke a callback, it still increments the MsgSeqNum(34) value.