### PR TITLE
philadelphia-core: Improve Logout(5) handling

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -546,6 +546,12 @@ public class FIXConnection implements Closeable {
             }
 
             if (msgSeqNum != rxMsgSeqNum) {
+                // Sometimes a logout request can be paired with the 'MsgSeqNum too low' error
+                // which doesn't allow to proceed with a Resend sequence
+                if (msgType.byteAt(0) == Logout) {
+                    handleLogout(message);
+                    return;
+                }
                 handleMsgSeqNum(message, msgType, msgSeqNum);
                 return;
             }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -546,12 +546,6 @@ public class FIXConnection implements Closeable {
             }
 
             if (msgSeqNum != rxMsgSeqNum) {
-                // Sometimes a logout request can be paired with the 'MsgSeqNum too low' error
-                // which doesn't allow to proceed with a Resend sequence
-                if (msgType.byteAt(0) == Logout) {
-                    handleLogout(message);
-                    return;
-                }
                 handleMsgSeqNum(message, msgType, msgSeqNum);
                 return;
             }
@@ -595,7 +589,9 @@ public class FIXConnection implements Closeable {
         }
 
         private void handleTooLowMsgSeqNum(FIXMessage message, FIXValue msgType, long msgSeqNum) throws IOException {
-            if (!msgType.contentEquals(SequenceReset)) {
+            if (msgType.contentEquals(Logout)) {
+                handleLogout(message);
+            } else if (!msgType.contentEquals(SequenceReset)) {
                 FIXValue possDupFlag = message.valueOf(PossDupFlag);
 
                 if (possDupFlag == null || possDupFlag.asBoolean() == false)

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -357,6 +357,25 @@ class FIXInitiatorTest {
     }
 
     @Test
+    void receiveLogoutWithTooLowMsgSeqNum() throws IOException {
+        initiator.setIncomingMsgSeqNum(2);
+
+        String message = "35=5|34=1|";
+        Event  status  = new Logout();
+
+        acceptorMessageInitiatorStatus(message, status);
+    }
+
+    @Test
+    void receiveLogoutWithTooHighMsgSeqNum() throws IOException {
+        String request  = "35=5|34=2|";
+        String response = "8=FIX.4.2|9=69|35=2|49=initiator|56=acceptor|34=1|" +
+            "52=19700101-00:00:00.000|7=1|16=0|10=093|";
+
+        acceptorRequestInitiatorResponse(request, response);
+    }
+
+    @Test
     void receiveFullBuffer() throws IOException {
         acceptor.send(asList("35=5|34=1|58=" + repeat('A', 512) + "|",
                 "35=5|34=2|58=" + repeat('A', 512) + "|"));


### PR DESCRIPTION
Handle a Logout(5) message with too low MsgSeqNum(34) value, but still send a ResendRequest(2) message when receiving a Logout(5) message with too high MsgSeqNum(34) value.

Supersedes #228.