### PR TITLE
philadelphia-generate: Require Python 3.7 or newer

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/applications/generate/README.md
+++ b/applications/generate/README.md
@@ -3,7 +3,7 @@
 Philadelphia Code Generator is a simple console application for generating
 Philadelphia profiles for FIX dialects.
 
-Philadelphia Code Generator requires Python 3.6 or newer.
+Philadelphia Code Generator requires Python 3.7 or newer.
 
 ## Features
 

--- a/scripts/generate-orchestra
+++ b/scripts/generate-orchestra
@@ -22,7 +22,7 @@
 #   https://www.fixtrading.org/standards/fix-orchestra/
 #
 # This script uses Philadelphia Code Generator and therefore requires Python
-# 3.6 or newer.
+# 3.7 or newer.
 #
 # As this repository already contains the generated FIX protocol versions, you
 # only need to run this script if FIX Latest updates or you change Philadelphia

--- a/scripts/generate-repository
+++ b/scripts/generate-repository
@@ -22,7 +22,7 @@
 #   https://www.fixtrading.org/standards/fix-repository/
 #
 # This script uses Philadelphia Code Generator and therefore requires Python
-# 3.6 or newer.
+# 3.7 or newer.
 #
 # As this repository already contains the generated FIX protocol versions, you
 # only need to run this script if you change Philadelphia Code Generator or add


### PR DESCRIPTION
Python 3.6 has reached end-of-life.