### PR TITLE
philadelphia-core: Improve 'FIXConnection' interface

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/package-info.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/package-info.java
@@ -31,7 +31,7 @@
  * connection keep-alive on another without locking. Data transmission and
  * connection keep-alive can run on different threads but require locking.</p>
  *
- * <p>The underlying socket channels can be either blocking or non-blocking.
- * In both cases, data transmission always blocks.</p>
+ * <p>The underlying channels can be either blocking or non-blocking. In both
+ * cases, data transmission always blocks.</p>
  */
 package com.paritytrading.philadelphia;


### PR DESCRIPTION
Refer to underlying channels rather than underlying socket channels everywhere.

Document the type bounds for the underlying channel type in the generic constructor, and retain a reference to [`SocketChannel`](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/SocketChannel.html), still the most common underlying channel type, in the Javadoc comment.

Prefer the terms "inbound" and "outbound" to the terms "RX" and "TX" in the API.