### PR TITLE
Fix 'maven-shade-plugin' configuration

### DIFF
--- a/applications/client/pom.xml
+++ b/applications/client/pom.xml
@@ -61,6 +61,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+              </excludes>
+            </filter>
+          </filters>
           <outputFile>philadelphia-client.jar</outputFile>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/examples/acceptor/pom.xml
+++ b/examples/acceptor/pom.xml
@@ -54,6 +54,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+              </excludes>
+            </filter>
+          </filters>
           <outputFile>philadelphia-acceptor.jar</outputFile>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/examples/initiator/pom.xml
+++ b/examples/initiator/pom.xml
@@ -58,6 +58,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+              </excludes>
+            </filter>
+          </filters>
           <outputFile>philadelphia-initiator.jar</outputFile>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.3.0</version>
           <configuration>
+            <createDependencyReducedPom>false</createDependencyReducedPom>
             <minimizeJar>true</minimizeJar>
           </configuration>
           <executions>

--- a/tests/perf-test/pom.xml
+++ b/tests/perf-test/pom.xml
@@ -63,6 +63,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+              </excludes>
+            </filter>
+          </filters>
           <minimizeJar>false</minimizeJar>
           <outputFile>philadelphia-perf-test.jar</outputFile>
           <transformers>


### PR DESCRIPTION
The plugin behavior has changed between the previously used version, 3.2.1, and the currently used version, 3.3.0.