### PR TITLE
philadelphia-core: Add 'FIXKeepAliveStatus'

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/Messages.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/Messages.java
@@ -52,10 +52,6 @@ class Messages implements FIXMessageListener, FIXConnectionStatusListener {
     }
 
     @Override
-    public void heartbeatTimeout(FIXConnection connection) {
-    }
-
-    @Override
     public void reject(FIXConnection connection, FIXMessage message) {
         add(message);
     }

--- a/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
+++ b/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
@@ -65,11 +65,6 @@ class Session implements FIXMessageListener {
             }
 
             @Override
-            public void heartbeatTimeout(FIXConnection connection) throws IOException {
-                connection.close();
-            }
-
-            @Override
             public void reject(FIXConnection connection, FIXMessage message) throws IOException {
             }
 

--- a/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/TestAcceptor.java
+++ b/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/TestAcceptor.java
@@ -15,6 +15,7 @@
  */
 package com.paritytrading.philadelphia.acceptor;
 
+import com.paritytrading.philadelphia.FIXKeepAliveStatus;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
@@ -48,7 +49,8 @@ class TestAcceptor {
 
             if (i % 1000 == 0) {
                 session.getConnection().setCurrentTimeMillis(System.currentTimeMillis());
-                session.getConnection().keepAlive();
+                if (session.getConnection().keepAlive() != FIXKeepAliveStatus.OK)
+                    break;
             }
 
             i++;

--- a/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
+++ b/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
@@ -62,11 +62,6 @@ class Initiator implements FIXMessageListener, Closeable {
             }
 
             @Override
-            public void heartbeatTimeout(FIXConnection connection) throws IOException {
-                connection.close();
-            }
-
-            @Override
             public void reject(FIXConnection connection, FIXMessage message) throws IOException {
             }
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -371,12 +371,13 @@ public class FIXConnection implements Closeable {
      *
      * <p>If a TestRequest(1) message has been sent and no data has been
      * received within the duration indicated by HeartBtInt(108) amended with
-     * a reasonable transmission time, trigger a status event indicating
-     * heartbeat timeout.</p>
+     * a reasonable transmission time, return a value indicating heartbeat
+     * timeout.</p>
      *
+     * @return the keep-alive status of this connection
      * @throws IOException if an I/O error occurs
      */
-    public void keepAlive() throws IOException {
+    public FIXKeepAliveStatus keepAlive() throws IOException {
         if (currentTimeMillis - lastTxMillis > heartbeatMillis)
             sendHeartbeat();
 
@@ -388,11 +389,13 @@ public class FIXConnection implements Closeable {
             }
         } else {
             if (currentTimeMillis - testRequestTxMillis > testRequestMillis) {
-                statusListener.heartbeatTimeout(this);
-
                 testRequestTxMillis = 0;
+
+                return FIXKeepAliveStatus.HEARTBEAT_TIMEOUT;
             }
         }
+
+        return FIXKeepAliveStatus.OK;
     }
 
     /**

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusListener.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusListener.java
@@ -51,14 +51,6 @@ public interface FIXConnectionStatusListener {
     void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) throws IOException;
 
     /**
-     * Receive an indication of a heartbeat timeout.
-     *
-     * @param connection the connection
-     * @throws IOException if an I/O error occurs
-     */
-    void heartbeatTimeout(FIXConnection connection) throws IOException;
-
-    /**
      * Receive a Reject(3) message.
      *
      * @param connection the connection

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXKeepAliveStatus.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXKeepAliveStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+/**
+ * The keep-alive status of a connection.
+ */
+public enum FIXKeepAliveStatus {
+
+    /**
+     * The connection is operational.
+     */
+    OK,
+
+    /**
+     * The connection has a heartbeat timeout.
+     */
+    HEARTBEAT_TIMEOUT,
+
+}

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
@@ -46,11 +46,6 @@ class FIXConnectionStatus implements FIXConnectionStatusListener {
     }
 
     @Override
-    public void heartbeatTimeout(FIXConnection connection) {
-        events.add(new HeartbeatTimeout());
-    }
-
-    @Override
     public void reject(FIXConnection connection, FIXMessage message) {
         events.add(new Reject());
     }
@@ -87,9 +82,6 @@ class FIXConnectionStatus implements FIXConnectionStatusListener {
             this.receivedMsgSeqNum = receivedMsgSeqNum;
             this.expectedMsgSeqNum = expectedMsgSeqNum;
         }
-    }
-
-    static class HeartbeatTimeout extends Value implements Event {
     }
 
     static class Reject extends Value implements Event {

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -76,14 +76,16 @@ abstract class FIXInitiatorTest {
     @Test
     void heartbeat() throws IOException {
         initiator.setCurrentTimeMillis(10_000);
-        initiator.keepAlive();
+
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         acceptor.send("35=0|34=1|");
         while (initiator.getIncomingMsgSeqNum() != 2)
             initiator.receive();
 
         initiator.setCurrentTimeMillis(35_000);
-        initiator.keepAlive();
+
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         String message = "8=FIX.4.2|9=60|35=0|49=initiator|56=acceptor|34=1|" +
             "52=19700101-00:00:35.000|10=223|";
@@ -94,13 +96,15 @@ abstract class FIXInitiatorTest {
     @Test
     void testRequest() throws IOException {
         initiator.setCurrentTimeMillis(32_500);
-        initiator.keepAlive();
+
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         String heartbeat = "8=FIX.4.2|9=60|35=0|49=initiator|56=acceptor|34=1|" +
             "52=19700101-00:00:32.500|10=225|";
 
         initiator.setCurrentTimeMillis(35_000);
-        initiator.keepAlive();
+
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         String testRequest = "8=FIX.4.2|9=86|35=1|49=initiator|56=acceptor|34=2|" +
             "52=19700101-00:00:35.000|112=19700101-00:00:35.000|10=213|";
@@ -111,9 +115,8 @@ abstract class FIXInitiatorTest {
     @Test
     void testResponse() throws IOException {
         initiator.setCurrentTimeMillis(35_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(), initiatorStatus.collect());
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         acceptor.send("35=0|34=1|");
 
@@ -121,42 +124,35 @@ abstract class FIXInitiatorTest {
             initiator.receive();
 
         initiator.setCurrentTimeMillis(60_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(), initiatorStatus.collect());
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         initiator.setCurrentTimeMillis(70_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(), initiatorStatus.collect());
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         initiator.setCurrentTimeMillis(75_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(), initiatorStatus.collect());
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
     }
 
     @Test
     void heartbeatTimeout() throws IOException {
         initiator.setCurrentTimeMillis(35_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(), initiatorStatus.collect());
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         initiator.setCurrentTimeMillis(40_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(), initiatorStatus.collect());
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
 
         initiator.setCurrentTimeMillis(70_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(new HeartbeatTimeout()), initiatorStatus.collect());
+        assertEquals(FIXKeepAliveStatus.HEARTBEAT_TIMEOUT, initiator.keepAlive());
 
         initiator.setCurrentTimeMillis(75_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(new HeartbeatTimeout()), initiatorStatus.collect());
+        assertEquals(FIXKeepAliveStatus.OK, initiator.keepAlive());
     }
 
     @Test


### PR DESCRIPTION
Signal a heartbeat timeout using the `FIXConnection#keepAlive()` return value rather than via the `FIXConnectionStatusListener` interface.

The purpose of this change is to separate the administrative message handling implemented in `FIXConnection#keepAlive()` from that currently implemented in a private inner class of `FIXConnection`. All callbacks
in `FIXConnectionStatusListener` except `heartbeatTimeout()` are invoked by the inner class. By making `FIXConnection#keepAlive()` independent of `FIXConnectionStatusListener`, `FIXConnection` in whole will become independent of it. This will make it possible to move the inner class out of `FIXConnection` and allow applications to provide their own implementations of administrative message handling.