### PR TITLE
Clean up 'maven-shade-plugin' configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,6 @@
           <version>3.3.0</version>
           <configuration>
             <createDependencyReducedPom>false</createDependencyReducedPom>
-            <minimizeJar>true</minimizeJar>
           </configuration>
           <executions>
             <execution>

--- a/tests/perf-test/pom.xml
+++ b/tests/perf-test/pom.xml
@@ -71,7 +71,6 @@
               </excludes>
             </filter>
           </filters>
-          <minimizeJar>false</minimizeJar>
           <outputFile>philadelphia-perf-test.jar</outputFile>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
Do not minimize JARs anymore. This has the following small impact on the executable JAR sizes:

  Name                   | Size Difference(KiB)
  -----------------------|--------------------:
  `philadelphia-client`    |                  +42
  `philadelphia-acceptor`  |                   +8
  `philadelphia-initiator` |                 +104
  `philadelphia-perf-test` |                    0