### PR TITLE
Fix 'maven-javadoc-plugin' configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <doclint>all,-missing</doclint>
-          <excludePackageNames>com.paritytrading.philadelphia.acceptor:com.paritytrading.philadelphia.client:com.paritytrading.philadelphia.initiator:*.generated</excludePackageNames>
+          <excludePackageNames>com.paritytrading.philadelphia.acceptor:com.paritytrading.philadelphia.client:com.paritytrading.philadelphia.initiator:*.jmh_generated</excludePackageNames>
           <sourceFileExcludes>**\/*Benchmark.java</sourceFileExcludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
The package name JMH uses for generated code has changed between JMH 1.23 and JMH 1.35.