### PR TITLE
Proper initialization of lastTxMillis and lastRxMillis.

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/Session.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/Session.java
@@ -68,7 +68,7 @@ class Session implements Closeable {
 
         channel.register(selector, SelectionKey.OP_READ);
 
-        FIXConnection connection = new FIXConnection(channel, config, listener, statusListener);
+        FIXConnection connection = new FIXConnection(channel, config, listener, statusListener, System.currentTimeMillis());
 
         return new Session(selector, connection);
     }

--- a/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
+++ b/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
@@ -84,7 +84,7 @@ class Session implements FIXMessageListener {
                 connection.sendLogout();
             }
 
-        });
+        }, System.currentTimeMillis());
 
         report = connection.create();
 

--- a/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
+++ b/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
@@ -79,7 +79,7 @@ class Initiator implements FIXMessageListener, Closeable {
                 connection.sendLogout();
             }
 
-        });
+        }, System.currentTimeMillis());
 
         histogram = new Histogram(3);
     }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -100,13 +100,14 @@ public class FIXConnection implements Closeable {
      * @param config the connection configuration
      * @param listener the inbound message listener
      * @param statusListener the inbound status event listener
+     * @param currentTimeMillis the current time in milliseconds
      * @param <CHANNEL> the underlying channel type, which must implement
      *   {@link ReadableByteChannel} and {@link GatheringByteChannel}
      * @see SocketChannel
      */
     public <CHANNEL extends ReadableByteChannel & GatheringByteChannel>
-    FIXConnection(CHANNEL channel, FIXConfig config, FIXMessageListener listener, FIXConnectionStatusListener statusListener) {
-        this(channel, channel, config, listener, statusListener);
+    FIXConnection(CHANNEL channel, FIXConfig config, FIXMessageListener listener, FIXConnectionStatusListener statusListener, long currentTimeMillis) {
+        this(channel, channel, config, listener, statusListener, currentTimeMillis);
     }
 
     /**
@@ -119,9 +120,10 @@ public class FIXConnection implements Closeable {
      * @param config the connection configuration
      * @param listener the inbound message listener
      * @param statusListener the inbound status event listener
+     * @param currentTimeMillis the current time in milliseconds
      */
     public FIXConnection(ReadableByteChannel inboundChannel, GatheringByteChannel outboundChannel,
-                         FIXConfig config, FIXMessageListener listener, FIXConnectionStatusListener statusListener) {
+                         FIXConfig config, FIXMessageListener listener, FIXConnectionStatusListener statusListener, long currentTimeMillis) {
         this.rxChannel = inboundChannel;
         this.txChannel = outboundChannel;
 
@@ -158,8 +160,8 @@ public class FIXConnection implements Closeable {
         this.txBuffers[0] = txHeaderBuffer;
         this.txBuffers[1] = txBodyBuffer;
 
-        this.lastRxMillis = 0;
-        this.lastTxMillis = 0;
+        this.lastRxMillis = currentTimeMillis;
+        this.lastTxMillis = currentTimeMillis;
 
         this.heartbeatMillis = config.getHeartBtInt() * 1000;
 
@@ -169,9 +171,10 @@ public class FIXConnection implements Closeable {
 
         this.adminMessage = new FIXMessage(ADMIN_MESSAGE_MAX_FIELD_COUNT, config.getFieldCapacity());
 
-        this.currentTimeMillis = 0;
+        this.currentTimeMillis = currentTimeMillis;
 
         this.currentTime = new FIXTimestamp();
+        this.currentTime.setEpochMilli(currentTimeMillis);
 
         this.currentTimestamp = new FIXValue(CURRENT_TIMESTAMP_FIELD_CAPACITY);
 

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConfigTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConfigTest.java
@@ -27,7 +27,7 @@ class FIXConfigTest {
         FIXConfig config = FIXConfig.newBuilder()
                 .setVersion(FIXVersion.FIXT_1_1)
                 .build();
-        new FIXConnection(null, config, null, null);
+        new FIXConnection(null, config, null, null, 0);
     }
 
     @Test

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -68,7 +68,7 @@ abstract class FIXInitiatorTest {
         Channels channels = createChannels();
         initiator = new FIXConnection(
                 channels.initiatorRx, channels.initiatorTx,
-                initiatorConfig, initiatorMessages, initiatorStatus
+                initiatorConfig, initiatorMessages, initiatorStatus, 0
         );
         acceptor  = new TestConnection(channels.acceptorRx, channels.acceptorTx, acceptorMessages);
     }


### PR DESCRIPTION
Current initialization with 0 leads to potential messages before the Logon message.

Fixes #301 