### PR TITLE
philadelphia-core: Restore 'FIXVersion#getBeginString()'

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
@@ -27,7 +27,7 @@ public class FIXConfig {
     /**
      * The default BeginString(8).
      */
-    public static final byte[] DEFAULT_BEGIN_STRING = FIXVersion.FIX_4_2.getBeginString();
+    public static final byte[] DEFAULT_BEGIN_STRING = FIXVersion.FIX_4_2.getBeginString().getBytes(US_ASCII);
 
     /**
      * The default SenderCompID(49).

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXVersion.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXVersion.java
@@ -15,9 +15,6 @@
  */
 package com.paritytrading.philadelphia;
 
-import static com.paritytrading.philadelphia.FIX.*;
-import static java.nio.charset.StandardCharsets.*;
-
 /**
  * The protocol version.
  */
@@ -53,13 +50,18 @@ public enum FIXVersion {
      */
     FIXT_1_1("FIXT.1.1");
 
-    private final byte[] beginString;
+    private final String beginString;
 
     private FIXVersion(String beginString) {
-        this.beginString = beginString.getBytes(US_ASCII);
+        this.beginString = beginString;
     }
 
-    byte[] getBeginString() {
+    /**
+     * Get the BeginString(8).
+     *
+     * @return the BeginString(8)
+     */
+    public String getBeginString() {
         return beginString;
     }
 


### PR DESCRIPTION
Retain backwards compatibility.