### PR TITLE
Improve 'maven-javadoc-plugin' configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
           <version>3.4.1</version>
           <configuration>
             <failOnWarnings>true</failOnWarnings>
+            <quiet>true</quiet>
             <source>${java.version}</source>
           </configuration>
         </plugin>


### PR DESCRIPTION
Only output warnings and errors from the plugin.