### PR TITLE
philadelphia-core: Refactor heartbeat timeout handling

### DIFF
--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/Messages.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/Messages.java
@@ -52,10 +52,6 @@ class Messages implements FIXMessageListener, FIXConnectionStatusListener {
     }
 
     @Override
-    public void heartbeatTimeout(FIXConnection connection) {
-    }
-
-    @Override
     public void reject(FIXConnection connection, FIXMessage message) {
         add(message);
     }

--- a/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
+++ b/examples/acceptor/src/main/java/com/paritytrading/philadelphia/acceptor/Session.java
@@ -63,11 +63,6 @@ class Session implements FIXMessageListener {
             }
 
             @Override
-            public void heartbeatTimeout(FIXConnection connection) throws IOException {
-                connection.close();
-            }
-
-            @Override
             public void reject(FIXConnection connection, FIXMessage message) throws IOException {
             }
 

--- a/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
+++ b/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
@@ -62,11 +62,6 @@ class Initiator implements FIXMessageListener, Closeable {
             }
 
             @Override
-            public void heartbeatTimeout(FIXConnection connection) throws IOException {
-                connection.close();
-            }
-
-            @Override
             public void reject(FIXConnection connection, FIXMessage message) throws IOException {
             }
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusListener.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusListener.java
@@ -51,14 +51,6 @@ public interface FIXConnectionStatusListener {
     void tooLowMsgSeqNum(FIXConnection connection, long receivedMsgSeqNum, long expectedMsgSeqNum) throws IOException;
 
     /**
-     * Receive an indication of a heartbeat timeout.
-     *
-     * @param connection the connection
-     * @throws IOException if an I/O error occurs
-     */
-    void heartbeatTimeout(FIXConnection connection) throws IOException;
-
-    /**
      * Receive a Reject(3) message.
      *
      * @param connection the connection

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXHeartbeatTimeoutException.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXHeartbeatTimeoutException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+/**
+ * Indicates a heartbeat timeout.
+ */
+public class FIXHeartbeatTimeoutException extends FIXException {
+
+    /**
+     * Construct an instance with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public FIXHeartbeatTimeoutException(String message) {
+        super(message);
+    }
+
+}

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConnectionStatus.java
@@ -46,11 +46,6 @@ class FIXConnectionStatus implements FIXConnectionStatusListener {
     }
 
     @Override
-    public void heartbeatTimeout(FIXConnection connection) {
-        events.add(new HeartbeatTimeout());
-    }
-
-    @Override
     public void reject(FIXConnection connection, FIXMessage message) {
         events.add(new Reject());
     }
@@ -87,9 +82,6 @@ class FIXConnectionStatus implements FIXConnectionStatusListener {
             this.receivedMsgSeqNum = receivedMsgSeqNum;
             this.expectedMsgSeqNum = expectedMsgSeqNum;
         }
-    }
-
-    static class HeartbeatTimeout extends Value implements Event {
     }
 
     static class Reject extends Value implements Event {

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -149,14 +149,11 @@ abstract class FIXInitiatorTest {
         assertEquals(asList(), initiatorStatus.collect());
 
         initiator.setCurrentTimeMillis(70_000);
-        initiator.keepAlive();
 
-        assertEquals(asList(new HeartbeatTimeout()), initiatorStatus.collect());
+        assertThrows(FIXHeartbeatTimeoutException.class, () -> initiator.keepAlive());
 
         initiator.setCurrentTimeMillis(75_000);
         initiator.keepAlive();
-
-        assertEquals(asList(new HeartbeatTimeout()), initiatorStatus.collect());
     }
 
     @Test


### PR DESCRIPTION
Replace the `FIXConnectionStatusListener#heartbeatTimeout()` method with a `FIXHeartbeatTimeoutException` class. The purpose of this change is to separate heartbeat timeout handling, which is implemented in the `FIXConnection` class, from other administrative message handling. This is in preparation of making it possible for applications to implement their own administrative message handling.