### PR TITLE
philadelphia-core: Clean up terminology

### DIFF
--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
@@ -47,12 +47,12 @@ public class FIXConfig {
     /**
      * The default incoming MsgSeqNum(34).
      */
-    public static final int DEFAULT_INCOMING_MSG_SEQ_NUM = 1;
+    public static final int DEFAULT_IN_MSG_SEQ_NUM = 1;
 
     /**
      * The default outgoing MsgSeqNum(34).
      */
-    public static final int DEFAULT_OUTGOING_MSG_SEQ_NUM = 1;
+    public static final int DEFAULT_OUT_MSG_SEQ_NUM = 1;
 
     /**
      * The default maximum number of fields.
@@ -88,8 +88,8 @@ public class FIXConfig {
     private final String  senderCompId;
     private final String  targetCompId;
     private final int     heartBtInt;
-    private final long    incomingMsgSeqNum;
-    private final long    outgoingMsgSeqNum;
+    private final long    inMsgSeqNum;
+    private final long    outMsgSeqNum;
     private final int     maxFieldCount;
     private final int     fieldCapacity;
     private final int     rxBufferCapacity;
@@ -103,8 +103,8 @@ public class FIXConfig {
      * @param senderCompId the SenderCompID(49)
      * @param targetCompId the TargetCompID(56)
      * @param heartBtInt the HeartBtInt(108)
-     * @param incomingMsgSeqNum the incoming MsgSeqNum(34)
-     * @param outgoingMsgSeqNum the outgoing MsgSeqNum(34)
+     * @param inMsgSeqNum the incoming MsgSeqNum(34)
+     * @param outMsgSeqNum the outgoing MsgSeqNum(34)
      * @param maxFieldCount the maximum number of fields in a message
      * @param fieldCapacity the field capacity
      * @param rxBufferCapacity the receive buffer capacity
@@ -113,21 +113,21 @@ public class FIXConfig {
      * @see #newBuilder
      */
     public FIXConfig(byte[] beginString, String senderCompId,
-            String targetCompId, int heartBtInt,
-            long incomingMsgSeqNum, long outgoingMsgSeqNum,
-            int maxFieldCount, int fieldCapacity, int rxBufferCapacity,
-            int txBufferCapacity, boolean checkSumEnabled) {
-        this.beginString       = beginString;
-        this.senderCompId      = senderCompId;
-        this.targetCompId      = targetCompId;
-        this.heartBtInt        = heartBtInt;
-        this.incomingMsgSeqNum = incomingMsgSeqNum;
-        this.outgoingMsgSeqNum = outgoingMsgSeqNum;
-        this.maxFieldCount     = maxFieldCount;
-        this.fieldCapacity     = fieldCapacity;
-        this.rxBufferCapacity  = rxBufferCapacity;
-        this.txBufferCapacity  = txBufferCapacity;
-        this.checkSumEnabled   = checkSumEnabled;
+            String targetCompId, int heartBtInt, long inMsgSeqNum,
+            long outMsgSeqNum, int maxFieldCount, int fieldCapacity,
+            int rxBufferCapacity, int txBufferCapacity,
+            boolean checkSumEnabled) {
+        this.beginString      = beginString;
+        this.senderCompId     = senderCompId;
+        this.targetCompId     = targetCompId;
+        this.heartBtInt       = heartBtInt;
+        this.inMsgSeqNum      = inMsgSeqNum;
+        this.outMsgSeqNum     = outMsgSeqNum;
+        this.maxFieldCount    = maxFieldCount;
+        this.fieldCapacity    = fieldCapacity;
+        this.rxBufferCapacity = rxBufferCapacity;
+        this.txBufferCapacity = txBufferCapacity;
+        this.checkSumEnabled  = checkSumEnabled;
     }
 
     /**
@@ -171,8 +171,8 @@ public class FIXConfig {
      *
      * @return the incoming MsgSeqNum(34)
      */
-    public long getIncomingMsgSeqNum() {
-        return incomingMsgSeqNum;
+    public long getInMsgSeqNum() {
+        return inMsgSeqNum;
     }
 
     /**
@@ -180,8 +180,8 @@ public class FIXConfig {
      *
      * @return the outgoing MsgSeqNum(34)
      */
-    public long getOutgoingMsgSeqNum() {
-        return outgoingMsgSeqNum;
+    public long getOutMsgSeqNum() {
+        return outMsgSeqNum;
     }
 
     /**
@@ -243,8 +243,8 @@ public class FIXConfig {
             .append("senderCompId=\"").append(senderCompId).append("\",")
             .append("targetCompId=\"").append(targetCompId).append("\",")
             .append("heartBtInt=").append(heartBtInt).append(",")
-            .append("incomingMsgSeqNum=").append(incomingMsgSeqNum).append(",")
-            .append("outgoingMsgSeqNum=").append(outgoingMsgSeqNum).append(",")
+            .append("inMsgSeqNum=").append(inMsgSeqNum).append(",")
+            .append("outMsgSeqNum=").append(outMsgSeqNum).append(",")
             .append("maxFieldCount=").append(maxFieldCount).append(",")
             .append("fieldCapacity=").append(fieldCapacity).append(",")
             .append("rxBufferCapacity=").append(rxBufferCapacity).append(",")
@@ -272,8 +272,8 @@ public class FIXConfig {
         private String  senderCompId;
         private String  targetCompId;
         private int     heartBtInt;
-        private long    incomingMsgSeqNum;
-        private long    outgoingMsgSeqNum;
+        private long    inMsgSeqNum;
+        private long    outMsgSeqNum;
         private int     maxFieldCount;
         private int     fieldCapacity;
         private int     rxBufferCapacity;
@@ -284,17 +284,17 @@ public class FIXConfig {
          * Create a connection configuration builder.
          */
         public Builder() {
-            beginString       = DEFAULT_BEGIN_STRING;
-            senderCompId      = DEFAULT_SENDER_COMP_ID;
-            targetCompId      = DEFAULT_TARGET_COMP_ID;
-            heartBtInt        = DEFAULT_HEART_BT_INT;
-            incomingMsgSeqNum = DEFAULT_INCOMING_MSG_SEQ_NUM;
-            outgoingMsgSeqNum = DEFAULT_OUTGOING_MSG_SEQ_NUM;
-            maxFieldCount     = DEFAULT_MAX_FIELD_COUNT;
-            fieldCapacity     = DEFAULT_FIELD_CAPACITY;
-            rxBufferCapacity  = DEFAULT_RX_BUFFER_CAPACITY;
-            txBufferCapacity  = DEFAULT_TX_BUFFER_CAPACITY;
-            checkSumEnabled   = DEFAULT_CHECK_SUM_ENABLED;
+            beginString      = DEFAULT_BEGIN_STRING;
+            senderCompId     = DEFAULT_SENDER_COMP_ID;
+            targetCompId     = DEFAULT_TARGET_COMP_ID;
+            heartBtInt       = DEFAULT_HEART_BT_INT;
+            inMsgSeqNum      = DEFAULT_IN_MSG_SEQ_NUM;
+            outMsgSeqNum     = DEFAULT_OUT_MSG_SEQ_NUM;
+            maxFieldCount    = DEFAULT_MAX_FIELD_COUNT;
+            fieldCapacity    = DEFAULT_FIELD_CAPACITY;
+            rxBufferCapacity = DEFAULT_RX_BUFFER_CAPACITY;
+            txBufferCapacity = DEFAULT_TX_BUFFER_CAPACITY;
+            checkSumEnabled  = DEFAULT_CHECK_SUM_ENABLED;
         }
 
         /**
@@ -370,11 +370,11 @@ public class FIXConfig {
         /**
          * Set the incoming MsgSeqNum(34).
          *
-         * @param incomingMsgSeqNum the incoming MsgSeqNum(34)
+         * @param inMsgSeqNum the incoming MsgSeqNum(34)
          * @return this instance
          */
-        public Builder setIncomingMsgSeqNum(long incomingMsgSeqNum) {
-            this.incomingMsgSeqNum = incomingMsgSeqNum;
+        public Builder setInMsgSeqNum(long inMsgSeqNum) {
+            this.inMsgSeqNum = inMsgSeqNum;
 
             return this;
         }
@@ -382,11 +382,11 @@ public class FIXConfig {
         /**
          * Set the outgoing MsgSeqNum(34).
          *
-         * @param outgoingMsgSeqNum the outgoing MsgSeqNum(34)
+         * @param outMsgSeqNum the outgoing MsgSeqNum(34)
          * @return this instance
          */
-        public Builder setOutgoingMsgSeqNum(long outgoingMsgSeqNum) {
-            this.outgoingMsgSeqNum = outgoingMsgSeqNum;
+        public Builder setOutMsgSeqNum(long outMsgSeqNum) {
+            this.outMsgSeqNum = outMsgSeqNum;
 
             return this;
         }
@@ -459,9 +459,9 @@ public class FIXConfig {
          */
         public FIXConfig build() {
             return new FIXConfig(beginString, senderCompId, targetCompId,
-                    heartBtInt, incomingMsgSeqNum, outgoingMsgSeqNum,
-                    maxFieldCount, fieldCapacity, rxBufferCapacity,
-                    txBufferCapacity, checkSumEnabled);
+                    heartBtInt, inMsgSeqNum, outMsgSeqNum, maxFieldCount,
+                    fieldCapacity, rxBufferCapacity, txBufferCapacity,
+                    checkSumEnabled);
         }
 
     }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusHandler.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusHandler.java
@@ -61,12 +61,12 @@ class FIXConnectionStatusHandler implements FIXMessageListener {
                 return;
         }
 
-        if (msgSeqNum != connection.getIncomingMsgSeqNum()) {
+        if (msgSeqNum != connection.getInMsgSeqNum()) {
             handleMsgSeqNum(message, msgType, msgSeqNum);
             return;
         }
 
-        connection.incrementIncomingMsgSeqNum();
+        connection.incrementInMsgSeqNum();
 
         if (msgType.length() != 1) {
             listener.message(message);
@@ -98,7 +98,7 @@ class FIXConnectionStatusHandler implements FIXMessageListener {
     }
 
     private void handleMsgSeqNum(FIXMessage message, FIXValue msgType, long msgSeqNum) throws IOException {
-        long rxMsgSeqNum = connection.getIncomingMsgSeqNum();
+        long rxMsgSeqNum = connection.getInMsgSeqNum();
 
         if (msgSeqNum < rxMsgSeqNum)
             handleTooLowMsgSeqNum(message, msgType, msgSeqNum);
@@ -107,7 +107,7 @@ class FIXConnectionStatusHandler implements FIXMessageListener {
     }
 
     private void handleTooLowMsgSeqNum(FIXMessage message, FIXValue msgType, long msgSeqNum) throws IOException {
-        long rxMsgSeqNum = connection.getIncomingMsgSeqNum();
+        long rxMsgSeqNum = connection.getInMsgSeqNum();
 
         if (msgType.contentEquals(Logout)) {
             handleLogout(message);
@@ -147,7 +147,7 @@ class FIXConnectionStatusHandler implements FIXMessageListener {
         }
 
         long endSeqNo = value.asInt();
-        long txMsgSeqNum = connection.getOutgoingMsgSeqNum();
+        long txMsgSeqNum = connection.getOutMsgSeqNum();
 
         if (beginSeqNo > txMsgSeqNum) {
             connection.sendReject(message.getMsgSeqNum(), ValueIsIncorrect, "BeginSeqNo(7) too high");
@@ -164,7 +164,7 @@ class FIXConnectionStatusHandler implements FIXMessageListener {
     }
 
     private boolean handleSequenceReset(FIXMessage message) throws IOException {
-        long rxMsgSeqNum = connection.getIncomingMsgSeqNum();
+        long rxMsgSeqNum = connection.getInMsgSeqNum();
 
         FIXValue value = message.valueOf(NewSeqNo);
         if (value == null) {
@@ -178,7 +178,7 @@ class FIXConnectionStatusHandler implements FIXMessageListener {
             return true;
         }
 
-        connection.setIncomingMsgSeqNum(newSeqNo);
+        connection.setInMsgSeqNum(newSeqNo);
 
         FIXValue gapFillFlag = message.valueOf(GapFillFlag);
         boolean reset = gapFillFlag == null || gapFillFlag.asBoolean() == false;
@@ -241,13 +241,13 @@ class FIXConnectionStatusHandler implements FIXMessageListener {
         adminMessage.addField(GapFillFlag).setBoolean(true);
         adminMessage.addField(NewSeqNo).setInt(newSeqNo);
 
-        decrementOutgoingMsgSeqNum();
+        decrementOutMsgSeqNum();
 
         connection.send(adminMessage);
     }
 
-    private void decrementOutgoingMsgSeqNum() {
-        connection.setOutgoingMsgSeqNum(connection.getOutgoingMsgSeqNum() - 1);
+    private void decrementOutMsgSeqNum() {
+        connection.setOutMsgSeqNum(connection.getOutMsgSeqNum() - 1);
     }
 
     private void msgSeqNumNotFound() throws IOException {

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConfigTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConfigTest.java
@@ -38,8 +38,8 @@ class FIXConfigTest {
                 "senderCompId=\"\"," +
                 "targetCompId=\"\"," +
                 "heartBtInt=30," +
-                "incomingMsgSeqNum=1," +
-                "outgoingMsgSeqNum=1," +
+                "inMsgSeqNum=1," +
+                "outMsgSeqNum=1," +
                 "maxFieldCount=64," +
                 "fieldCapacity=64," +
                 "rxBufferCapacity=1024," +

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -79,7 +79,7 @@ abstract class FIXInitiatorTest {
         initiator.keepAlive();
 
         acceptor.send("35=0|34=1|");
-        while (initiator.getIncomingMsgSeqNum() != 2)
+        while (initiator.getInMsgSeqNum() != 2)
             initiator.receive();
 
         initiator.setCurrentTimeMillis(35_000);
@@ -117,7 +117,7 @@ abstract class FIXInitiatorTest {
 
         acceptor.send("35=0|34=1|");
 
-        while (initiator.getIncomingMsgSeqNum() != 2)
+        while (initiator.getInMsgSeqNum() != 2)
             initiator.receive();
 
         initiator.setCurrentTimeMillis(60_000);
@@ -175,7 +175,7 @@ abstract class FIXInitiatorTest {
 
     @Test
     void receiveMessageWithTooLowMsgSeqNum() throws IOException {
-        initiator.setIncomingMsgSeqNum(2);
+        initiator.setInMsgSeqNum(2);
 
         String message = "35=0|34=1|";
         Event status   = new TooLowMsgSeqNum(1, 2);
@@ -212,50 +212,50 @@ abstract class FIXInitiatorTest {
 
     @Test
     void receiveResendRequestWithEndSeqNoSmallerThanLastMsgSeqNum() throws IOException {
-        initiator.setOutgoingMsgSeqNum(5);
+        initiator.setOutMsgSeqNum(5);
 
         String request  = "35=2|34=1|7=2|16=3|";
         String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
             "52=19700101-00:00:00.000|123=Y|36=4|10=230|";
 
         acceptorRequestInitiatorResponse(request, response);
-        assertEquals(5, initiator.getOutgoingMsgSeqNum());
+        assertEquals(5, initiator.getOutMsgSeqNum());
     }
 
     @Test
     void receiveResendRequestWithEndSeqNoEqualToLastMsgSeqNum() throws IOException {
-        initiator.setOutgoingMsgSeqNum(5);
+        initiator.setOutMsgSeqNum(5);
 
         String request  = "35=2|34=1|7=2|16=4|";
         String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
             "52=19700101-00:00:00.000|123=Y|36=5|10=231|";
 
         acceptorRequestInitiatorResponse(request, response);
-        assertEquals(5, initiator.getOutgoingMsgSeqNum());
+        assertEquals(5, initiator.getOutMsgSeqNum());
     }
 
     @Test
     void receiveResendRequestWithEndSeqNoLargerThanLastMsgSeqNum() throws IOException {
-        initiator.setOutgoingMsgSeqNum(5);
+        initiator.setOutMsgSeqNum(5);
 
         String request  = "35=2|34=1|7=2|16=6|";
         String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
             "52=19700101-00:00:00.000|123=Y|36=5|10=231|";
 
         acceptorRequestInitiatorResponse(request, response);
-        assertEquals(5, initiator.getOutgoingMsgSeqNum());
+        assertEquals(5, initiator.getOutMsgSeqNum());
     }
 
     @Test
     void receiveResendRequestWithZeroEndSeqNo() throws IOException {
-        initiator.setOutgoingMsgSeqNum(3);
+        initiator.setOutMsgSeqNum(3);
 
         String request  = "35=2|34=1|7=2|16=0|";
         String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
             "52=19700101-00:00:00.000|123=Y|36=3|10=229|";
 
         acceptorRequestInitiatorResponse(request, response);
-        assertEquals(3, initiator.getOutgoingMsgSeqNum());
+        assertEquals(3, initiator.getOutMsgSeqNum());
     }
 
     @Test
@@ -287,7 +287,7 @@ abstract class FIXInitiatorTest {
 
     @Test
     void receiveResendRequestWithTooHighEndSeqNo() throws IOException {
-        initiator.setOutgoingMsgSeqNum(3);
+        initiator.setOutMsgSeqNum(3);
 
         String request  = "35=2|34=1|7=2|16=5|";
         String response = "8=FIX.4.2|9=71|35=4|49=initiator|56=acceptor|34=2|" +
@@ -306,7 +306,7 @@ abstract class FIXInitiatorTest {
 
     @Test
     void receiveSequenceResetResetWithTooLowMsgSeqNum() throws IOException {
-        initiator.setIncomingMsgSeqNum(2);
+        initiator.setInMsgSeqNum(2);
 
         String message = "35=4|34=1|36=5|";
         Event  status  = new SequenceReset();
@@ -335,7 +335,7 @@ abstract class FIXInitiatorTest {
     void receiveSequenceResetGapFill() throws IOException {
         acceptor.send("35=4|34=1|123=Y|36=5|");
 
-        while (initiator.getIncomingMsgSeqNum() != 5)
+        while (initiator.getInMsgSeqNum() != 5)
             initiator.receive();
     }
 
@@ -357,7 +357,7 @@ abstract class FIXInitiatorTest {
 
     @Test
     void receiveLogoutWithTooLowMsgSeqNum() throws IOException {
-        initiator.setIncomingMsgSeqNum(2);
+        initiator.setInMsgSeqNum(2);
 
         String message = "35=5|34=1|";
         Event  status  = new Logout();
@@ -379,7 +379,7 @@ abstract class FIXInitiatorTest {
         acceptor.send(asList("35=5|34=1|58=" + repeat('A', 512) + "|",
                 "35=5|34=2|58=" + repeat('A', 512) + "|"));
 
-        while (initiator.getIncomingMsgSeqNum() != 3)
+        while (initiator.getInMsgSeqNum() != 3)
             initiator.receive();
 
         assertEquals(asList(), acceptorMessages.collect());


### PR DESCRIPTION
For brevity, prefer "in" instead of "incoming" and "out" instead of "outgoing" in method names. Align some method parameter names with corresponding instance variable names.