### PR TITLE
philadelphia-initiator: Fix message handling

### DIFF
--- a/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
+++ b/examples/initiator/src/main/java/com/paritytrading/philadelphia/initiator/Initiator.java
@@ -121,14 +121,17 @@ class Initiator implements FIXMessageListener, Closeable {
     }
 
     void sendAndReceive(FIXMessage message, FIXValue clOrdId, int orders) throws IOException {
+        int sendCount = 0;
+
         for (long sentAtNanoTime = System.nanoTime(); receiveCount < orders; connection.receive()) {
-            if (System.nanoTime() >= sentAtNanoTime) {
+            if (System.nanoTime() >= sentAtNanoTime && sendCount < orders) {
                 clOrdId.setInt(sentAtNanoTime);
 
                 connection.update(message);
                 connection.send(message);
 
                 sentAtNanoTime += intervalNanos;
+                sendCount++;
             }
         }
     }


### PR DESCRIPTION
Ensure that we only send as many orders as requested to avoid the application terminating the TCP connection while having outstanding NewOrderSingle(D) requests pending ExecutionReport(8) responses.