### PR TITLE
philadelphia-core: Fix 'FIXInitiatorTest#receiveLogonWithTooLowMsgSeqNum()'

### DIFF
--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXInitiatorTest.java
@@ -359,10 +359,11 @@ abstract class FIXInitiatorTest {
 
         acceptor.send(message);
 
-        while (initiatorStatus.collect().size() < 1) {
+        while (initiatorStatus.collect().size() < 1)
             initiator.receive();
+
+        while (acceptorMessages.collect().size() < 1)
             acceptor.receive();
-        }
 
         assertEquals(asList(response), acceptorMessages.collect());
         assertEquals(asList(), initiatorMessages.collect());


### PR DESCRIPTION
The test is currently not deterministic, as the receive loop may be exited before the acceptor has received the Logout(5) message. Make the test deterministic by having individual receive loops for the initiator and the acceptor.