### PR TITLE
philadelphia-core: Introduce message capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 See the [upgrade instructions](UPGRADE-2.1.0.md).
 
+- Introduce message capacity (Jussi Virtanen)
+
+  Simplify configuration by introducing the concept of message capacity: the
+  number of fields a message container can hold. A message container starts at
+  its initial message capacity and grows when necessary until it reaches its
+  maximum message capacity.
+
 - Update FIX Latest support to EP276 (Jussi Virtanen)
 
 - Specify Java module names (Jussi Virtanen)

--- a/UPGRADE-2.1.0.md
+++ b/UPGRADE-2.1.0.md
@@ -2,6 +2,37 @@
 
 Philadelphia 2.1.0 contains minor API changes. See below for details.
 
+## Message capacity
+
+Philadelphia 2.1.0 introduces the concept of message capacity: the number
+of fields a message container can hold. It provides two new configuration
+parameters for this purpose: the initial message capacity and the maximum
+message capacity. A message container will grow when necessary, but its
+capacity will not exceed its maximum.
+
+The default initial message capacity is 64 fields, and the default maximum
+message capacity is 65536 fields. Use the `setMinMessageCapacity()` and
+`setMaxMessageCapacity()` methods in `FIXConfig.Builder` to alter these.
+
+The `FIXConfig.Builder#setMaxFieldCount()` method is now deprecated. If you
+want to retain the same behavior, use the `setMessageCapacity()` method
+instead. It sets both the initial and the maximum message capacity to the
+same value. See below for an example.
+
+Before:
+```java
+FIXConfig config = FIXConfig.newBuilder()
+        .setMaxFieldCount(128)
+        .build();
+```
+
+After:
+```java
+FIXConfig config = FIXConfig.newBuilder()
+        .setMessageCapacity(128)
+        .build();
+```
+
 ## Java modules
 
 Philadelphia 2.1.0 introduces rudimentary Java module support by setting module

--- a/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
+++ b/applications/client/src/main/java/com/paritytrading/philadelphia/client/TerminalClient.java
@@ -202,7 +202,6 @@ class TerminalClient implements Closeable {
             .setSenderCompID(senderCompId)
             .setTargetCompID(targetCompId)
             .setHeartBtInt(heartBtInt)
-            .setMaxFieldCount(1024)
             .setFieldCapacity(1024)
             .setRxBufferCapacity(1024 * 1024)
             .setTxBufferCapacity(1024 * 1024);

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIX.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIX.java
@@ -35,6 +35,6 @@ class FIX {
 
     static final int CHECK_SUM_FIELD_CAPACITY = 8;
 
-    static final int ADMIN_MESSAGE_MAX_FIELD_COUNT = 8;
+    static final int ADMIN_MESSAGE_CAPACITY = 8;
 
 }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConfig.java
@@ -55,8 +55,19 @@ public class FIXConfig {
     public static final int DEFAULT_OUT_MSG_SEQ_NUM = 1;
 
     /**
+     * The default minimum message capacity.
+     */
+    public static final int DEFAULT_MIN_MESSAGE_CAPACITY = 64;
+
+    /**
+     * The default maximum message capacity.
+     */
+    public static final int DEFAULT_MAX_MESSAGE_CAPACITY = 65536;
+
+    /**
      * The default maximum number of fields.
      */
+    @Deprecated
     public static final int DEFAULT_MAX_FIELD_COUNT = 64;
 
     /**
@@ -90,7 +101,8 @@ public class FIXConfig {
     private final int     heartBtInt;
     private final long    inMsgSeqNum;
     private final long    outMsgSeqNum;
-    private final int     maxFieldCount;
+    private final int     minMessageCapacity;
+    private final int     maxMessageCapacity;
     private final int     fieldCapacity;
     private final int     rxBufferCapacity;
     private final int     txBufferCapacity;
@@ -105,7 +117,8 @@ public class FIXConfig {
      * @param heartBtInt the HeartBtInt(108)
      * @param inMsgSeqNum the incoming MsgSeqNum(34)
      * @param outMsgSeqNum the outgoing MsgSeqNum(34)
-     * @param maxFieldCount the maximum number of fields in a message
+     * @param minMessageCapacity the initial message capacity
+     * @param maxMessageCapacity the maximum message capacity
      * @param fieldCapacity the field capacity
      * @param rxBufferCapacity the receive buffer capacity
      * @param txBufferCapacity the transmit buffer capacity
@@ -114,20 +127,22 @@ public class FIXConfig {
      */
     public FIXConfig(byte[] beginString, String senderCompId,
             String targetCompId, int heartBtInt, long inMsgSeqNum,
-            long outMsgSeqNum, int maxFieldCount, int fieldCapacity,
+            long outMsgSeqNum, int minMessageCapacity,
+            int maxMessageCapacity, int fieldCapacity,
             int rxBufferCapacity, int txBufferCapacity,
             boolean checkSumEnabled) {
-        this.beginString      = beginString;
-        this.senderCompId     = senderCompId;
-        this.targetCompId     = targetCompId;
-        this.heartBtInt       = heartBtInt;
-        this.inMsgSeqNum      = inMsgSeqNum;
-        this.outMsgSeqNum     = outMsgSeqNum;
-        this.maxFieldCount    = maxFieldCount;
-        this.fieldCapacity    = fieldCapacity;
-        this.rxBufferCapacity = rxBufferCapacity;
-        this.txBufferCapacity = txBufferCapacity;
-        this.checkSumEnabled  = checkSumEnabled;
+        this.beginString        = beginString;
+        this.senderCompId       = senderCompId;
+        this.targetCompId       = targetCompId;
+        this.heartBtInt         = heartBtInt;
+        this.inMsgSeqNum        = inMsgSeqNum;
+        this.outMsgSeqNum       = outMsgSeqNum;
+        this.minMessageCapacity = minMessageCapacity;
+        this.maxMessageCapacity = maxMessageCapacity;
+        this.fieldCapacity      = fieldCapacity;
+        this.rxBufferCapacity   = rxBufferCapacity;
+        this.txBufferCapacity   = txBufferCapacity;
+        this.checkSumEnabled    = checkSumEnabled;
     }
 
     /**
@@ -185,12 +200,32 @@ public class FIXConfig {
     }
 
     /**
+     * Get the initial message capacity.
+     *
+     * @return the initial message capacity
+     */
+    public int getMinMessageCapacity() {
+        return minMessageCapacity;
+    }
+
+    /**
+     * Get the maximum message capacity.
+     *
+     * @return the maximum message capacity
+     */
+    public int getMaxMessageCapacity() {
+        return maxMessageCapacity;
+    }
+
+    /**
      * Get the maximum number of fields in a message.
      *
      * @return the maximum number of fields in a message
+     * @see #getMaxMessageCapacity
      */
+    @Deprecated
     public int getMaxFieldCount() {
-        return maxFieldCount;
+        return getMaxMessageCapacity();
     }
 
     /**
@@ -245,7 +280,8 @@ public class FIXConfig {
             .append("heartBtInt=").append(heartBtInt).append(",")
             .append("inMsgSeqNum=").append(inMsgSeqNum).append(",")
             .append("outMsgSeqNum=").append(outMsgSeqNum).append(",")
-            .append("maxFieldCount=").append(maxFieldCount).append(",")
+            .append("minMessageCapacity=").append(minMessageCapacity).append(",")
+            .append("maxMessageCapacity=").append(maxMessageCapacity).append(",")
             .append("fieldCapacity=").append(fieldCapacity).append(",")
             .append("rxBufferCapacity=").append(rxBufferCapacity).append(",")
             .append("txBufferCapacity=").append(txBufferCapacity).append(",")
@@ -274,7 +310,8 @@ public class FIXConfig {
         private int     heartBtInt;
         private long    inMsgSeqNum;
         private long    outMsgSeqNum;
-        private int     maxFieldCount;
+        private int     minMessageCapacity;
+        private int     maxMessageCapacity;
         private int     fieldCapacity;
         private int     rxBufferCapacity;
         private int     txBufferCapacity;
@@ -284,17 +321,18 @@ public class FIXConfig {
          * Create a connection configuration builder.
          */
         public Builder() {
-            beginString      = DEFAULT_BEGIN_STRING;
-            senderCompId     = DEFAULT_SENDER_COMP_ID;
-            targetCompId     = DEFAULT_TARGET_COMP_ID;
-            heartBtInt       = DEFAULT_HEART_BT_INT;
-            inMsgSeqNum      = DEFAULT_IN_MSG_SEQ_NUM;
-            outMsgSeqNum     = DEFAULT_OUT_MSG_SEQ_NUM;
-            maxFieldCount    = DEFAULT_MAX_FIELD_COUNT;
-            fieldCapacity    = DEFAULT_FIELD_CAPACITY;
-            rxBufferCapacity = DEFAULT_RX_BUFFER_CAPACITY;
-            txBufferCapacity = DEFAULT_TX_BUFFER_CAPACITY;
-            checkSumEnabled  = DEFAULT_CHECK_SUM_ENABLED;
+            beginString        = DEFAULT_BEGIN_STRING;
+            senderCompId       = DEFAULT_SENDER_COMP_ID;
+            targetCompId       = DEFAULT_TARGET_COMP_ID;
+            heartBtInt         = DEFAULT_HEART_BT_INT;
+            inMsgSeqNum        = DEFAULT_IN_MSG_SEQ_NUM;
+            outMsgSeqNum       = DEFAULT_OUT_MSG_SEQ_NUM;
+            minMessageCapacity = DEFAULT_MIN_MESSAGE_CAPACITY;
+            maxMessageCapacity = DEFAULT_MAX_MESSAGE_CAPACITY;
+            fieldCapacity      = DEFAULT_FIELD_CAPACITY;
+            rxBufferCapacity   = DEFAULT_RX_BUFFER_CAPACITY;
+            txBufferCapacity   = DEFAULT_TX_BUFFER_CAPACITY;
+            checkSumEnabled    = DEFAULT_CHECK_SUM_ENABLED;
         }
 
         /**
@@ -392,15 +430,60 @@ public class FIXConfig {
         }
 
         /**
+         * Set the initial message capacity.
+         *
+         * @param minMessageCapacity the initial message capacity
+         * @return this instance
+         * @see #setMaxMessageCapacity
+         * @see #setMessageCapacity
+         */
+        public Builder setMinMessageCapacity(int minMessageCapacity) {
+            this.minMessageCapacity = minMessageCapacity;
+
+            return this;
+        }
+
+        /**
+         * Set the maximum message capacity.
+         *
+         * @param maxMessageCapacity the maximum message capacity
+         * @return this instance
+         * @see #setMinMessageCapacity
+         * @see #setMessageCapacity
+         */
+        public Builder setMaxMessageCapacity(int maxMessageCapacity) {
+            this.maxMessageCapacity = maxMessageCapacity;
+
+            return this;
+        }
+
+        /**
+         * Set both the initial message capacity and the maximum message
+         * capacity.
+         *
+         * @param messageCapacity the initial as well as the maximum message
+         *     capacity
+         * @return this instance
+         * @see #setMinMessageCapacity
+         * @see #setMaxMessageCapacity
+         */
+        public Builder setMessageCapacity(int messageCapacity) {
+            this.minMessageCapacity = messageCapacity;
+            this.maxMessageCapacity = messageCapacity;
+
+            return this;
+        }
+
+        /**
          * Set the maximum number of fields in a message.
          *
          * @param maxFieldCount the maximum number of fields in a message
          * @return this instance
+         * @see #setMessageCapacity
          */
+        @Deprecated
         public Builder setMaxFieldCount(int maxFieldCount) {
-            this.maxFieldCount = maxFieldCount;
-
-            return this;
+            return setMessageCapacity(maxFieldCount);
         }
 
         /**
@@ -459,9 +542,9 @@ public class FIXConfig {
          */
         public FIXConfig build() {
             return new FIXConfig(beginString, senderCompId, targetCompId,
-                    heartBtInt, inMsgSeqNum, outMsgSeqNum, maxFieldCount,
-                    fieldCapacity, rxBufferCapacity, txBufferCapacity,
-                    checkSumEnabled);
+                    heartBtInt, inMsgSeqNum, outMsgSeqNum, minMessageCapacity,
+                    maxMessageCapacity, fieldCapacity, rxBufferCapacity,
+                    txBufferCapacity, checkSumEnabled);
         }
 
     }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnection.java
@@ -195,7 +195,7 @@ public class FIXConnection implements Closeable {
 
         this.testRequestTxMillis = 0;
 
-        this.adminMessage = new FIXMessage(ADMIN_MESSAGE_MAX_FIELD_COUNT, config.getFieldCapacity());
+        this.adminMessage = new FIXMessage(ADMIN_MESSAGE_CAPACITY, config.getFieldCapacity());
 
         this.currentTimeMillis = currentTimeMillis;
 

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusHandler.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXConnectionStatusHandler.java
@@ -39,7 +39,7 @@ class FIXConnectionStatusHandler implements FIXMessageListener {
 
         this.statusListener = statusListener;
 
-        this.adminMessage = new FIXMessage(ADMIN_MESSAGE_MAX_FIELD_COUNT, config.getFieldCapacity());
+        this.adminMessage = new FIXMessage(ADMIN_MESSAGE_CAPACITY, config.getFieldCapacity());
     }
 
     @Override

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConfigTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXConfigTest.java
@@ -40,7 +40,8 @@ class FIXConfigTest {
                 "heartBtInt=30," +
                 "inMsgSeqNum=1," +
                 "outMsgSeqNum=1," +
-                "maxFieldCount=64," +
+                "minMessageCapacity=64," +
+                "maxMessageCapacity=65536," +
                 "fieldCapacity=64," +
                 "rxBufferCapacity=1024," +
                 "txBufferCapacity=1024," +

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXMessageParserTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXMessageParserTest.java
@@ -156,7 +156,7 @@ class FIXMessageParserTest {
 
     private boolean parse(ByteBuffer buffer, boolean checkSumEnabled) throws IOException {
         FIXConfig config = FIXConfig.newBuilder()
-            .setMaxFieldCount(32)
+            .setMessageCapacity(32)
             .setFieldCapacity(32)
             .setCheckSumEnabled(checkSumEnabled)
             .build();


### PR DESCRIPTION
Simplify configuration by introducing the concept of message capacity: the number of fields a message container can hold. A message container starts at its initial message capacity and grows when necessary until it reaches its maximum message capacity.

This change introduces one conditional statement on the fast path, in the `FIXMessage#addField()` method. Based on the performance test, this has no measurable impact. Note that for the best performance, an application should still set the initial and the maximum message capacity to the same value, as growing a message container will have discernible effect.