### PR TITLE
Specify Java module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.1.0 (????-??-??)
+
+- Specify Java module names (Jussi Virtanen)
+
+  Introduce minimal Java module support by specifying module names for all
+  libraries corresponding to their package names.
+
 ## 2.0.0 (2022-10-29)
 
 See the [upgrade instructions](UPGRADE-2.0.0.md).

--- a/UPGRADE-2.1.0.md
+++ b/UPGRADE-2.1.0.md
@@ -1,0 +1,32 @@
+# Upgrading to Philadelphia 2.1.0
+
+Philadelphia 2.1.0 contains minor API changes. See below for details.
+
+## Java modules
+
+Philadelphia 2.1.0 introduces rudimentary Java module support by setting module
+names for all Philadelphia libraries. These correspond to their package names.
+For example, the module name for Philadelphia Core is:
+```
+com.paritytrading.philadelphia
+```
+
+If you use Java modules in your application and currently reference
+Philadelphia libraries using module names derived from their JAR names (as the
+JDK does by default), start using module names that correspond to their package
+names instead. See below for an example.
+
+Before:
+```java
+module example {
+    requires philadelphia.core;
+    requires philadelphia.fix42;
+}
+```
+
+After:
+```java
+module example {
+    requires com.paritytrading.philadelphia;
+    requires com.paritytrading.philadelphia.fix42;
+}

--- a/libraries/core/pom.xml
+++ b/libraries/core/pom.xml
@@ -45,4 +45,20 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fix40/pom.xml
+++ b/libraries/fix40/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX 4.0</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fix40</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fix41/pom.xml
+++ b/libraries/fix41/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX 4.1</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fix41</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fix42/pom.xml
+++ b/libraries/fix42/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX 4.2</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fix42</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fix43/pom.xml
+++ b/libraries/fix43/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX 4.3</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fix43</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fix44/pom.xml
+++ b/libraries/fix44/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX 4.4</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fix44</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fix50/pom.xml
+++ b/libraries/fix50/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX 5.0</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fix50</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fix50sp1/pom.xml
+++ b/libraries/fix50sp1/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX 5.0 SP1</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fix50sp1</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fix50sp2/pom.xml
+++ b/libraries/fix50sp2/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX 5.0 SP2</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fix50sp2</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fixlatest/pom.xml
+++ b/libraries/fixlatest/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIX Latest</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fixlatest</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/libraries/fixt11/pom.xml
+++ b/libraries/fixt11/pom.xml
@@ -28,4 +28,20 @@
 
   <name>Philadelphia FIXT 1.1</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.fixt11</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.4.1</version>
           <configuration>

--- a/scripts/archive.txt
+++ b/scripts/archive.txt
@@ -4,6 +4,7 @@ README.md
 UPGRADE-1.0.0.md
 UPGRADE-1.2.0.md
 UPGRADE-2.0.0.md
+UPGRADE-2.1.0.md
 applications/client/README.md
 applications/client/etc/example.conf
 applications/client/etc/example.txt


### PR DESCRIPTION
Introduce minimal Java module support by specifying module names for all libraries corresponding to their package names.