### PR TITLE
Improve 'maven-compiler-plugin' configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,27 @@
       </build>
     </profile>
     <profile>
+      <id>jdk-21-or-newer</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs>
+                <arg>-Xlint:deprecation</arg>
+                <arg>-Xlint:unchecked</arg>
+                <arg>-proc:full</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>release</id>
       <build>
         <plugins>


### PR DESCRIPTION
Specify `-proc:full` on Java 21 to silence a compilation warning.