### PR TITLE
philadelphia-generate: Require Python 3.9 or newer

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/applications/generate/README.md
+++ b/applications/generate/README.md
@@ -3,7 +3,7 @@
 Philadelphia Code Generator is a simple console application for generating
 Philadelphia profiles for FIX dialects.
 
-Philadelphia Code Generator requires Python 3.8 or newer.
+Philadelphia Code Generator requires Python 3.9 or newer.
 
 ## Features
 

--- a/documentation/generate.md
+++ b/documentation/generate.md
@@ -7,7 +7,7 @@ As Philadelphia already contains the output of the code generation process,
 users do not need to deal with code generation at all. Developers only need to
 deal with it if either the specifications change or the process itself changes.
 
-Code generation requires Bash and Python 3.8 or newer.
+Code generation requires Bash and Python 3.9 or newer.
 
 ## Generating code from FIX Repository
 

--- a/documentation/release.md
+++ b/documentation/release.md
@@ -5,7 +5,7 @@ Philadelphia releases are published to [Maven Central Repository][] via
 
 Publishing a release requires access to the Parity project on Sonatype OSSRH,
 write permission to the Philadelphia repository on GitHub, access to the Parity
-project on Mastodon, and Python 3.8 or newer.
+project on Mastodon, and Python 3.9 or newer.
 
   [Maven Central Repository]: https://search.maven.org/
   [Sonatype OSSRH]: https://central.sonatype.org/publish/publish-guide/

--- a/scripts/generate-orchestra
+++ b/scripts/generate-orchestra
@@ -22,7 +22,7 @@
 #   https://www.fixtrading.org/standards/fix-orchestra/
 #
 # This script uses Philadelphia Code Generator and therefore requires Python
-# 3.7 or newer.
+# 3.9 or newer.
 #
 # As this repository already contains the generated FIX protocol versions, you
 # only need to run this script if FIX Latest or FIXT 1.1 updates or you change

--- a/scripts/generate-repository
+++ b/scripts/generate-repository
@@ -22,7 +22,7 @@
 #   https://www.fixtrading.org/standards/fix-repository/
 #
 # This script uses Philadelphia Code Generator and therefore requires Python
-# 3.7 or newer.
+# 3.9 or newer.
 #
 # As this repository already contains the generated FIX protocol versions, you
 # only need to run this script if you change Philadelphia Code Generator or add


### PR DESCRIPTION
Python 3.8 has reached end-of-life.