### PR TITLE
philadelphia-perf-test: Use 'Mode.AverageTime'

### DIFF
--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXBenchmark.java
@@ -30,6 +30,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @Fork(value = 3)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@BenchmarkMode(Mode.SampleTime)
+@BenchmarkMode(Mode.AverageTime)
 abstract class FIXBenchmark {
 }


### PR DESCRIPTION
With `Mode.SampleTime`, the timestamping logic enveloping each benchmark invocation easily dwarfs tight benchmark methods themselves. Switch to `Mode.AverageTime` instead; it amortizes the cost of the timestamping logic over multiple benchmark invocations, giving a more representative view of their performance.