### PR TITLE
core: Improve 'FIXValue#asInt()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 See the [upgrade instructions](UPGRADE-2.1.0.md).
 
+- Improve `FIXValue#asInt()` (Jussi Virtanen)
+
+  Previously the method returned zero if the value consisted of zero bytes or
+  a single `-` byte, and previously the return value overflowed if it did not
+  fit into a `long`. Now the method throws a `FIXValueFormatException` instead
+  in both cases. These changes have a negligible negative performance impact of
+  less than 0.1 ns/op on the fast path based on the benchmark results on Apple
+  MacBook Pro (M1 Pro, 2021).
+
 - Introduce message capacity (Jussi Virtanen)
 
   Simplify configuration by introducing the concept of message capacity: the

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+class FIXIntDecoder {
+
+    static long decode(byte[] bytes, int offset, int length) {
+        boolean negative = false;
+
+        int i = offset;
+
+        if (bytes[i] == '-') {
+            negative = true;
+
+            i++;
+        }
+
+        long x = 0;
+
+        while (i < offset + length) {
+            byte b = bytes[i++];
+
+            if (b < '0' || b > '9')
+                notInt();
+
+            x = 10 * x + b - '0';
+        }
+
+        return negative ? -x : +x;
+    }
+
+    private static void notInt() throws FIXValueFormatException {
+        throw new FIXValueFormatException("Not an integer");
+    }
+
+}

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
@@ -18,15 +18,14 @@ package com.paritytrading.philadelphia;
 class FIXIntDecoder {
 
     static long decode(byte[] bytes, int offset, int length) {
-        boolean negative = false;
+        if (bytes[offset] == '-')
+            return decodeNegative(bytes, offset, length);
+        else
+            return decodePositive(bytes, offset, length);
+    }
 
+    private static long decodePositive(byte[] bytes, int offset, int length) {
         int i = offset;
-
-        if (bytes[i] == '-') {
-            negative = true;
-
-            i++;
-        }
 
         long x = 0;
 
@@ -39,7 +38,24 @@ class FIXIntDecoder {
             x = 10 * x + b - '0';
         }
 
-        return negative ? -x : +x;
+        return x;
+    }
+
+    private static long decodeNegative(byte[] bytes, int offset, int length) {
+        int i = offset + 1;
+
+        long x = 0;
+
+        while (i < offset + length) {
+            byte b = bytes[i++];
+
+            if (b < '0' || b > '9')
+                notInt();
+
+            x = 10 * x + '0' - b;
+        }
+
+        return x;
     }
 
     private static void notInt() throws FIXValueFormatException {

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
@@ -27,9 +27,11 @@ class FIXIntDecoder {
     private static long decodePositive(byte[] bytes, int offset, int length) {
         int i = offset;
 
+        int endIndex = offset + length;
+
         long x = 0;
 
-        while (i < offset + length) {
+        while (i < endIndex) {
             byte b = bytes[i++];
 
             if (b < '0' || b > '9')
@@ -44,9 +46,11 @@ class FIXIntDecoder {
     private static long decodeNegative(byte[] bytes, int offset, int length) {
         int i = offset + 1;
 
+        int endIndex = offset + length;
+
         long x = 0;
 
-        while (i < offset + length) {
+        while (i < endIndex) {
             byte b = bytes[i++];
 
             if (b < '0' || b > '9')

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
@@ -21,6 +21,9 @@ class FIXIntDecoder {
     private static final int MAX_POSITIVE_LENGTH = 19;
 
     static long decode(byte[] bytes, int offset, int length) {
+        if (length == 0)
+            notInt();
+
         if (bytes[offset] == '-') {
             if (length >= MAX_NEGATIVE_LENGTH)
                 return decodeNegativeExact(bytes, offset, length);
@@ -80,6 +83,9 @@ class FIXIntDecoder {
     }
 
     private static long decodeNegative(byte[] bytes, int offset, int length) {
+        if (length < 2)
+            notInt();
+
         int i = offset + 1;
 
         int endIndex = offset + length;

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXIntDecoder.java
@@ -17,11 +17,21 @@ package com.paritytrading.philadelphia;
 
 class FIXIntDecoder {
 
+    private static final int MAX_NEGATIVE_LENGTH = 20;
+    private static final int MAX_POSITIVE_LENGTH = 19;
+
     static long decode(byte[] bytes, int offset, int length) {
-        if (bytes[offset] == '-')
-            return decodeNegative(bytes, offset, length);
-        else
-            return decodePositive(bytes, offset, length);
+        if (bytes[offset] == '-') {
+            if (length >= MAX_NEGATIVE_LENGTH)
+                return decodeNegativeExact(bytes, offset, length);
+            else
+                return decodeNegative(bytes, offset, length);
+        } else {
+            if (length >= MAX_POSITIVE_LENGTH)
+                return decodePositiveExact(bytes, offset, length);
+            else
+                return decodePositive(bytes, offset, length);
+        }
     }
 
     private static long decodePositive(byte[] bytes, int offset, int length) {
@@ -38,6 +48,32 @@ class FIXIntDecoder {
                 notInt();
 
             x = 10 * x + b - '0';
+        }
+
+        return x;
+    }
+
+    private static long decodePositiveExact(byte[] bytes, int offset, int length) {
+        if (length > MAX_POSITIVE_LENGTH)
+            tooLargeInt();
+
+        int i = offset;
+
+        int endIndex = offset + length;
+
+        long x = 0;
+
+        while (i < endIndex) {
+            byte b = bytes[i++];
+
+            if (b < '0' || b > '9')
+                notInt();
+
+            try {
+                x = Math.addExact(Math.multiplyExact(x, 10), b - '0');
+            } catch (ArithmeticException e) {
+                tooLargeInt();
+            }
         }
 
         return x;
@@ -62,8 +98,42 @@ class FIXIntDecoder {
         return x;
     }
 
+    private static long decodeNegativeExact(byte[] bytes, int offset, int length) {
+        if (length > MAX_NEGATIVE_LENGTH)
+            tooSmallInt();
+
+        int i = offset + 1;
+
+        int endIndex = offset + length;
+
+        long x = 0;
+
+        while (i < endIndex) {
+            byte b = bytes[i++];
+
+            if (b < '0' || b > '9')
+                notInt();
+
+            try {
+                x = Math.addExact(Math.multiplyExact(x, 10), '0' - b);
+            } catch (ArithmeticException e) {
+                tooSmallInt();
+            }
+        }
+
+        return x;
+    }
+
     private static void notInt() throws FIXValueFormatException {
         throw new FIXValueFormatException("Not an integer");
+    }
+
+    private static void tooLargeInt() throws FIXValueFormatException {
+        throw new FIXValueFormatException("Too large integer");
+    }
+
+    private static void tooSmallInt() throws FIXValueFormatException {
+        throw new FIXValueFormatException("Too small integer");
     }
 
 }

--- a/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
+++ b/libraries/core/src/main/java/com/paritytrading/philadelphia/FIXValue.java
@@ -265,28 +265,7 @@ public class FIXValue implements CharSequence {
      * @throws FIXValueFormatException if the value is not an integer
      */
     public long asInt() {
-        boolean negative = false;
-
-        int i = offset;
-
-        if (bytes[i] == '-') {
-            negative = true;
-
-            i++;
-        }
-
-        long x = 0;
-
-        while (i < offset + length) {
-            byte b = bytes[i++];
-
-            if (b < '0' || b > '9')
-                notInt();
-
-            x = 10 * x + b - '0';
-        }
-
-        return negative ? -x : +x;
+        return FIXIntDecoder.decode(bytes, offset, length);
     }
 
     /**
@@ -759,10 +738,6 @@ public class FIXValue implements CharSequence {
 
     private static void notFloat() throws FIXValueFormatException {
         throw new FIXValueFormatException("Not a float");
-    }
-
-    private static void notInt() throws FIXValueFormatException {
-        throw new FIXValueFormatException("Not an integer");
     }
 
     private static void notTimeOnly() throws FIXValueFormatException {

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXIntDecoderTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXIntDecoderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+import static java.nio.charset.StandardCharsets.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class FIXIntDecoderTest {
+
+    @Test
+    void minValue() {
+        assertEquals(Long.MIN_VALUE, decode("-9223372036854775808"));
+    }
+
+    @Test
+    void minusOneHundredTwentyThree() {
+        assertEquals(-123, decode("-123"));
+    }
+
+    @Test
+    void minusOne() {
+        assertEquals(-1, decode("-1"));
+    }
+
+    @Test
+    void minusZero() {
+        assertEquals(0, decode("-0"));
+    }
+
+    @Test
+    void zero() {
+        assertEquals(0, decode("0"));
+    }
+
+    @Test
+    void one() {
+        assertEquals(1, decode("1"));
+    }
+
+    @Test
+    void oneHundredTwentyThree() {
+        assertEquals(123, decode("123"));
+    }
+
+    @Test
+    void maxValue() {
+        assertEquals(Long.MAX_VALUE, decode("9223372036854775807"));
+    }
+
+    @Test
+    void notInt() {
+        assertThrows(FIXValueFormatException.class, () -> decode("FOO"));
+    }
+
+    private static long decode(String value) {
+        byte[] bytes = (">" + value + "<").getBytes(US_ASCII);
+
+        return FIXIntDecoder.decode(bytes, 1, bytes.length - 2);
+    }
+
+}

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXIntDecoderTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXIntDecoderTest.java
@@ -64,8 +64,18 @@ class FIXIntDecoderTest {
     }
 
     @Test
+    void empty() {
+        assertNotInt("");
+    }
+
+    @Test
+    void minus() {
+        assertNotInt("-");
+    }
+
+    @Test
     void notInt() {
-        assertThrows(FIXValueFormatException.class, () -> decode("FOO"));
+        assertNotInt("FOO");
     }
 
     @Test
@@ -102,6 +112,10 @@ class FIXIntDecoderTest {
         byte[] bytes = (">" + value + "<").getBytes(US_ASCII);
 
         return FIXIntDecoder.decode(bytes, 1, bytes.length - 2);
+    }
+
+    private static void assertNotInt(String value) {
+        assertMessage("Not an integer", value);
     }
 
     private static void assertTooLargeInt(BigInteger value) {

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXIntDecoderTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXIntDecoderTest.java
@@ -18,6 +18,7 @@ package com.paritytrading.philadelphia;
 import static java.nio.charset.StandardCharsets.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
 
 class FIXIntDecoderTest {
@@ -67,10 +68,55 @@ class FIXIntDecoderTest {
         assertThrows(FIXValueFormatException.class, () -> decode("FOO"));
     }
 
+    @Test
+    void positiveAdditionOverflow() {
+        assertTooLargeInt(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE));
+    }
+
+    @Test
+    void positiveMultiplicationOverflow() {
+        assertTooLargeInt(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TEN));
+    }
+
+    @Test
+    void positiveLengthOverflow() {
+        assertTooLargeInt(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN));
+    }
+
+    @Test
+    void negativeAdditionOverflow() {
+        assertTooSmallInt(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE));
+    }
+
+    @Test
+    void negativeMultiplicationOverflow() {
+        assertTooSmallInt(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.TEN));
+    }
+
+    @Test
+    void negativeLengthOverflow() {
+        assertTooSmallInt(BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.TEN));
+    }
+
     private static long decode(String value) {
         byte[] bytes = (">" + value + "<").getBytes(US_ASCII);
 
         return FIXIntDecoder.decode(bytes, 1, bytes.length - 2);
+    }
+
+    private static void assertTooLargeInt(BigInteger value) {
+        assertMessage("Too large integer", value.toString());
+    }
+
+    private static void assertTooSmallInt(BigInteger value) {
+        assertMessage("Too small integer", value.toString());
+    }
+
+    private static void assertMessage(String message, String value) {
+        FIXValueFormatException exception = assertThrows(FIXValueFormatException.class,
+                () -> decode(value));
+
+        assertEquals(message, exception.getMessage());
     }
 
 }

--- a/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
+++ b/libraries/core/src/test/java/com/paritytrading/philadelphia/FIXValueTest.java
@@ -201,66 +201,10 @@ class FIXValueTest {
     }
 
     @Test
-    void asIntMinValue() {
-        get("-9223372036854775808\u0001");
-
-        assertEquals(Long.MIN_VALUE, value.asInt());
-    }
-
-    @Test
-    void asIntMinusOneHundredTwentyThree() {
-        get("-123\u0001");
-
-        assertEquals(-123, value.asInt());
-    }
-
-    @Test
-    void asIntMinusOne() {
-        get("-1\u0001");
-
-        assertEquals(-1, value.asInt());
-    }
-
-    @Test
-    void asIntMinusZero() {
-        get("-0\u0001");
-
-        assertEquals(0, value.asInt());
-    }
-
-    @Test
-    void asIntZero() {
-        get("0\u0001");
-
-        assertEquals(0, value.asInt());
-    }
-
-    @Test
-    void asIntOne() {
-        get("1\u0001");
-
-        assertEquals(1, value.asInt());
-    }
-
-    @Test
-    void asIntOneHundredTwentyThree() {
+    void asInt() {
         get("123\u0001");
 
         assertEquals(123, value.asInt());
-    }
-
-    @Test
-    void asIntMaxValue() {
-        get("9223372036854775807\u0001");
-
-        assertEquals(Long.MAX_VALUE, value.asInt());
-    }
-
-    @Test
-    void notInt() {
-        value.setString("FOO");
-
-        assertThrows(FIXValueFormatException.class, () -> value.asInt());
     }
 
     @Test

--- a/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXIntDecoderBenchmark.java
+++ b/tests/perf-test/src/main/java/com/paritytrading/philadelphia/FIXIntDecoderBenchmark.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Philadelphia authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paritytrading.philadelphia;
+
+import static java.nio.charset.StandardCharsets.*;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+
+public class FIXIntDecoderBenchmark extends FIXBenchmark {
+
+    private byte[] zeroBytes;
+    private byte[] maxFastPathBytes;
+    private byte[] maxValueBytes;
+
+    @Setup(Level.Iteration)
+    public void prepare() {
+        zeroBytes = getBytes("0");
+        maxFastPathBytes = getBytes("999999999999999999");
+        maxValueBytes = getBytes(Long.toString(Long.MAX_VALUE));
+    }
+
+    @Benchmark
+    public long decodeZero() {
+        return decode(zeroBytes);
+    }
+
+    @Benchmark
+    public long decodeMaxFastPath() {
+        return decode(maxFastPathBytes);
+    }
+
+    @Benchmark
+    public long decodeMaxValue() {
+        return decode(maxValueBytes);
+    }
+
+    private static long decode(byte[] bytes) {
+        return FIXIntDecoder.decode(bytes, 0, bytes.length);
+    }
+
+    private static byte[] getBytes(String value) {
+        return value.getBytes(US_ASCII);
+    }
+
+}


### PR DESCRIPTION
Throw `FIXValueFormatException` if
* the value consists of zero bytes,
* the value consists of a single `-` byte, or
* the value does not fit into a `long`.